### PR TITLE
Enhancement/prevent owner operation/teamInvite

### DIFF
--- a/src/components/Team/members/index.tsx
+++ b/src/components/Team/members/index.tsx
@@ -132,12 +132,20 @@ const Content = (props: Props) => {
     }
   ];
 
+  const { team } = props;
+  let isOwner = false;
+  if (team) {
+    isOwner = team.role === Roles.Owner;
+  }
+
   return (
     <div>
       <Title title="Members" breadcrumb={breadcrumbItems}>
         {__("You can manage members in your team.")}
       </Title>
-      <Invite />
+      {isOwner &&
+        <Invite />
+      }
 
       {/* each member management */}
       {currentMember && (


### PR DESCRIPTION
Related #143 

109行目に
`const member`
が存在し、
`const { members, team } = props`
を入れるとエラーが出たので、
`const { team } = props`
としたところ、正常に動作することを確認しました。