### PR TITLE
Send default language as locale attribute

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -15,8 +15,14 @@ const userPool = new CognitoIdentity.CognitoUserPool(poolData);
 
 export const signUp = (username: string, email: string, password: string) =>
   new Promise<CognitoIdentity.ISignUpResult>((resolve, reject) => {
+    // TODO: if we have more language option, let's extend
+    const language = navigator.language.slice(0, 2) === "ja" ? "ja" : "en";
     const attributeList = [
-      new CognitoIdentity.CognitoUserAttribute({ Name: "email", Value: email })
+      new CognitoIdentity.CognitoUserAttribute({ Name: "email", Value: email }),
+      new CognitoIdentity.CognitoUserAttribute({
+        Name: "locale",
+        Value: language
+      })
     ];
 
     userPool.signUp(username, password, attributeList, [], (err, result) => {

--- a/src/components/verify.tsx
+++ b/src/components/verify.tsx
@@ -71,6 +71,9 @@ const Content = (props: Props) => {
 
   return (
     <div className="signup">
+      {status && status !== "requesting" && (
+        <Alert type={status}>{messages[status]}</Alert>
+      )}
       <div className="container">
         <img src={Logo} alt="" className="logo" />
         <h1>{__("Welcome to Geolonia")}</h1>
@@ -124,9 +127,6 @@ const Content = (props: Props) => {
             "Please check your email and enter the verification code like 123456."
           )}
         </Alert>
-      )}
-      {status && status !== "requesting" && (
-        <Alert type={status}>{messages[status]}</Alert>
       )}
     </div>
   );


### PR DESCRIPTION
This patch make the dashboard to send browser language when signup and store it as initial language value.
The initial language value will be used i18nization of email.

```shell
# stored data example
$ AWS_DEFAULT_REGION=us-east-1 aws cognito-idp admin-get-user --user-pool-id=us-east-1_0C5yMqsfC --username=ryo102
{
    "Username": "ryo102",
    "Enabled": true,
    "UserStatus": "UNCONFIRMED",
    "UserCreateDate": 1580461505.231,
    "UserAttributes": [
        {
            "Name": "sub",
            "Value": "xxxx"
        },
        {
            "Name": "email_verified",
            "Value": "false"
        },
        {
            "Name": "locale",
            "Value": "ja"
        },
        {
            "Name": "email",
            "Value": "ryo+102@geolonia.com"
        }
    ],
    "UserLastModifiedDate": 1580461505.231
}
```