### PR TITLE
Add Origin normalizer

### DIFF
--- a/src/components/Maps/APIKey.tsx
+++ b/src/components/Maps/APIKey.tsx
@@ -26,6 +26,9 @@ import Redux from "redux";
 import { connect } from "react-redux";
 import { createActions as createMapKeyActions } from "../../redux/actions/map-key";
 
+// libs
+import normalizeOrigin from "../../lib/normalize-origin";
+
 // constants
 import { messageDisplayDuration } from "../../constants";
 
@@ -144,7 +147,8 @@ const Content = (props: Props) => {
 
     const normalizedAllowedOrigins = allowedOrigins
       .split("\n")
-      .filter(url => !!url);
+      .filter(url => !!url)
+      .map(origin => normalizeOrigin(origin));
 
     const nextKey = {
       name,

--- a/src/lib/normalize-origin.test.ts
+++ b/src/lib/normalize-origin.test.ts
@@ -1,0 +1,41 @@
+import normalizeOrigin from "./normalize-origin";
+
+test("should be normalized", () => {
+  const url = "  https://example.com  ";
+  expect(normalizeOrigin(url)).toEqual("https://example.com");
+});
+
+test("should be normalized slashed url", () => {
+  const url = "https://example.com/";
+  expect(normalizeOrigin(url)).toEqual("https://example.com");
+});
+
+test("should normalize localhost", () => {
+  const url = "https://localhost:12345/";
+  expect(normalizeOrigin(url)).toEqual("https://localhost:12345");
+});
+
+test("should normalize ip address", () => {
+  const url = "https://1.2.3.4:5678/";
+  expect(normalizeOrigin(url)).toEqual("https://1.2.3.4:5678");
+});
+
+test("should not be normalized slashed url", () => {
+  const url = "https://example.com";
+  expect(normalizeOrigin(url)).toEqual("https://example.com");
+});
+
+test("should not normalize localhost", () => {
+  const url = "https://localhost:12345";
+  expect(normalizeOrigin(url)).toEqual("https://localhost:12345");
+});
+
+test("should not normalize ip address", () => {
+  const url = "https://1.2.3.4:5678";
+  expect(normalizeOrigin(url)).toEqual("https://1.2.3.4:5678");
+});
+
+test("should not be normalized if not matched", () => {
+  const url = "invalid string";
+  expect(normalizeOrigin(url)).toEqual("invalid string");
+});

--- a/src/lib/normalize-origin.ts
+++ b/src/lib/normalize-origin.ts
@@ -1,0 +1,10 @@
+export const normalizeOrigin = (url: string) => {
+  const trimed = url.trim();
+  if (trimed[trimed.length - 1] === "/") {
+    return trimed.slice(0, trimed.length - 1);
+  } else {
+    return trimed;
+  }
+};
+
+export default normalizeOrigin;


### PR DESCRIPTION
Canonicalize origin.
`https://example.com/` should be canonicalized as `https://example.com`.