### PR TITLE
Show label row per page

### DIFF
--- a/src/components/custom/Table.tsx
+++ b/src/components/custom/Table.tsx
@@ -138,6 +138,7 @@ export const CustomTable = (props: Props) => {
                 inputProps: { "aria-label": __("rows per page") },
                 native: true
               }}
+              labelRowsPerPage={ __("rows per page") }
               onChangePage={(e, newPage) => setOffset(rowsPerPage * newPage)}
               onChangeRowsPerPage={e =>
                 setRowsPerPage(parseInt(e.target.value, 10))


### PR DESCRIPTION
`inputProps["aria-label"]: string` is just an accessibility attribute and no actual visible label texts have not specified 😅
close #242