### PR TITLE
Add error handling and message display for password reset page

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -120,9 +120,9 @@ export const sendVerificationEmail = (email: string) =>
     });
     if (cognitoUser) {
       cognitoUser.forgotPassword({
-        onSuccess: () => resolve(),
+        onSuccess: () => resolve(true),
         onFailure: err => {
-          reject(err.message || JSON.stringify(err));
+          reject(err);
         }
       });
     }

--- a/src/components/ForgotPassword.tsx
+++ b/src/components/ForgotPassword.tsx
@@ -9,8 +9,6 @@ import Logo from "./custom/logo.svg";
 import { CircularProgress } from "@material-ui/core";
 import { sendVerificationEmail } from "../auth";
 import delay from "../lib/promise-delay";
-import { connect } from "react-redux";
-import { createActions } from "../redux/actions/auth-support";
 import Alert from "./custom/Alert";
 
 type OwnProps = {};
@@ -19,9 +17,7 @@ type RouterProps = {
     push: (path: string) => void;
   };
 };
-type DispatchProps = {
-  setCurrentUser: (currentUser: string) => void;
-};
+type DispatchProps = {};
 type Props = OwnProps & RouterProps & DispatchProps;
 
 const Content = (props: Props) => {
@@ -36,9 +32,8 @@ const Content = (props: Props) => {
   ) => {
     event && event.preventDefault();
     setStatus("requesting");
-    props.setCurrentUser(email); // TODO: remove
     delay(sendVerificationEmail(email), 500)
-      .then(result => {
+      .then(() => {
         setStatus("success");
         props.history.push("/reset-password");
       })
@@ -110,9 +105,4 @@ const Content = (props: Props) => {
   );
 };
 
-const mapDispatchToProps = (dispatch: any) => ({
-  setCurrentUser: (currentUser: string) =>
-    dispatch(createActions.setCurrentUser(currentUser))
-});
-
-export default connect(void 0, mapDispatchToProps)(Content);
+export default Content;

--- a/src/components/ForgotPassword.tsx
+++ b/src/components/ForgotPassword.tsx
@@ -11,6 +11,7 @@ import { sendVerificationEmail } from "../auth";
 import delay from "../lib/promise-delay";
 import { connect } from "react-redux";
 import { createActions } from "../redux/actions/auth-support";
+import Alert from "./custom/Alert";
 
 type OwnProps = {};
 type RouterProps = {
@@ -24,41 +25,60 @@ type DispatchProps = {
 type Props = OwnProps & RouterProps & DispatchProps;
 
 const Content = (props: Props) => {
-  const [username, setUsername] = React.useState("");
+  const [email, setEmail] = React.useState("");
   const [status, setStatus] = React.useState<
-    null | "requesting" | "success" | "failure"
+    null | "requesting" | "success" | "warning"
   >(null);
+  const [message, setMessage] = React.useState("");
 
   const handleSignup = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     event && event.preventDefault();
     setStatus("requesting");
-    props.setCurrentUser(username);
-    delay(sendVerificationEmail(username), 500)
-      .then(() => {
+    props.setCurrentUser(email); // TODO: remove
+    delay(sendVerificationEmail(email), 500)
+      .then(result => {
         setStatus("success");
+        props.history.push("/reset-password");
       })
-      .catch(() => {
-        // TODO: show messages
-        setStatus("failure");
-      })
-      .finally(() => props.history.push("/reset-password"));
+      .catch(error => {
+        setStatus("warning");
+        if (error.code === "UserNotFoundException") {
+          setMessage(__("User not found. Please check entered username."));
+        } else if (
+          error.code === "InvalidParameterException" &&
+          error.message.indexOf("verified email") > -1
+        ) {
+          setMessage(
+            __(
+              "Cannot reset password for the user as there is no verified email."
+            )
+          );
+        } else if (error.code === "LimitExceededException") {
+          setMessage(__("Attempt limit exceeded, please try after some time."));
+        } else {
+          setMessage(__("Unknown error."));
+        }
+      });
   };
+
+  const buttonDisabled =
+    email.trim() === "" || status === "success" || status === "requesting";
 
   return (
     <div className="signup">
       <div className="container">
         <img src={Logo} alt="" className="logo" />
         <h1>{__("Reset your password")}</h1>
-
+        {status === "warning" && <Alert type={status}>{message}</Alert>}
         <form className="form">
           <label className="email">
-            <h3>{__("Username or email address")}</h3>
+            <h3>{__("Email address")}</h3>
             <input
               type="text"
-              value={username}
-              onChange={e => setUsername(e.target.value)}
+              value={email}
+              onChange={e => setEmail(e.target.value)}
             />
           </label>
           <p className="message">
@@ -69,7 +89,7 @@ const Content = (props: Props) => {
               variant="contained"
               color="primary"
               onClick={handleSignup}
-              disabled={username.trim() === ""}
+              disabled={buttonDisabled}
               type={"submit"}
             >
               {__("Send password reset email")}

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -57,8 +57,18 @@
       "Public URL": ["公開 URL"],
       "Invalid JSON.": [""],
       "%s feature has been added.": ["%s 個の地物が追加されました。"],
+      "User not found. Please check entered username.": [
+        "ユーザーが見つかりませんでした。ユーザー名を確認してください。"
+      ],
+      "Cannot reset password for the user as there is no verified email.": [
+        "メールアドレスが認証されていないため、このユーザーのパスワードをリセットできませんでした。"
+      ],
+      "Attempt limit exceeded, please try after some time.": [
+        "試行回数が制限を超えました。しばらくしてからまたお試しください。"
+      ],
+      "Unknown error.": ["不明なエラー。"],
       "Reset your password": ["パスワードのリセット"],
-      "Username or email address": ["ユーザー名または Email アドレス"],
+      "Email address": ["Email アドレス"],
       "We will send you a verification code to reset your password.": [
         "パスワードをリセットするための検証コードを送付します。"
       ],
@@ -148,6 +158,7 @@
       "Oops, the server seems not to be responding correctly.": [
         "おっと、サーバーが正しく応答していないようです。"
       ],
+      "Username or email address": ["ユーザー名または Email アドレス"],
       "Forgot password?": ["パスワードをお忘れですか？"],
       "Sign in": ["サインイン"],
       "New to Geolonia?": ["アカウントをお持ちですか？"],
@@ -155,11 +166,9 @@
       "Incorrect username, email address or password.": [
         "ユーザー名、 Email アドレス、またはパスワードが正しくありません。"
       ],
-      "Unknown error.": ["不明なエラー。"],
       "Username cannot be modified later.": [
         "ユーザー名は後から変更できません。"
       ],
-      "Email address": ["Email アドレス"],
       "Make sure at least 8 characters including a number and a lowercase letter.": [
         "パスワードには8文字以上で数字及び大文字小文字を含めるようにしてください。"
       ],
@@ -287,9 +296,6 @@
       "Verification code": ["検証コード"],
       "Verify": ["検証する"],
       "Verification code mismatch.": ["検証コードが一致しません。"],
-      "User not found. Please check entered username.": [
-        "ユーザーが見つかりませんでした。ユーザー名を確認してください。"
-      ],
       "Verify your account": ["アカウントの確認"],
       "Please check your email and enter the verification code like 123456.": [
         "Eメールを確認して 123456 のような検証コードを入力してください。"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -162,19 +162,36 @@ msgid "%s feature has been added."
 msgid_plural "%s features have been added."
 msgstr[0] "%s 個の地物が追加されました。"
 
-#: src/components/ForgotPassword.tsx:53
+#: src/components/ForgotPassword.tsx:48 src/components/verify.tsx:75
+msgid "User not found. Please check entered username."
+msgstr "ユーザーが見つかりませんでした。ユーザー名を確認してください。"
+
+#: src/components/ForgotPassword.tsx:54
+msgid "Cannot reset password for the user as there is no verified email."
+msgstr "メールアドレスが認証されていないため、このユーザーのパスワードをリセットできませんでした。"
+
+#: src/components/ForgotPassword.tsx:59
+msgid "Attempt limit exceeded, please try after some time."
+msgstr "試行回数が制限を超えました。しばらくしてからまたお試しください。"
+
+#: src/components/ForgotPassword.tsx:61 src/components/Signin.tsx:96
+#: src/constants.ts:17
+msgid "Unknown error."
+msgstr "不明なエラー。"
+
+#: src/components/ForgotPassword.tsx:73
 msgid "Reset your password"
 msgstr "パスワードのリセット"
 
-#: src/components/ForgotPassword.tsx:57 src/components/Signin.tsx:126
-msgid "Username or email address"
-msgstr "ユーザー名または Email アドレス"
+#: src/components/ForgotPassword.tsx:77 src/components/Signup.tsx:110
+msgid "Email address"
+msgstr "Email アドレス"
 
-#: src/components/ForgotPassword.tsx:65
+#: src/components/ForgotPassword.tsx:85
 msgid "We will send you a verification code to reset your password."
 msgstr "パスワードをリセットするための検証コードを送付します。"
 
-#: src/components/ForgotPassword.tsx:75
+#: src/components/ForgotPassword.tsx:95
 msgid "Send password reset email"
 msgstr "メールを送信"
 
@@ -404,6 +421,10 @@ msgstr ""
 msgid "Oops, the server seems not to be responding correctly."
 msgstr "おっと、サーバーが正しく応答していないようです。"
 
+#: src/components/Signin.tsx:126
+msgid "Username or email address"
+msgstr "ユーザー名または Email アドレス"
+
 #: src/components/Signin.tsx:150
 msgid "Forgot password?"
 msgstr "パスワードをお忘れですか？"
@@ -424,17 +445,9 @@ msgstr "アカウントを作成"
 msgid "Incorrect username, email address or password."
 msgstr "ユーザー名、 Email アドレス、またはパスワードが正しくありません。"
 
-#: src/components/Signin.tsx:96 src/constants.ts:17
-msgid "Unknown error."
-msgstr "不明なエラー。"
-
 #: src/components/Signup.tsx:106
 msgid "Username cannot be modified later."
 msgstr "ユーザー名は後から変更できません。"
-
-#: src/components/Signup.tsx:110
-msgid "Email address"
-msgstr "Email アドレス"
 
 #: src/components/Signup.tsx:130
 msgid ""
@@ -841,10 +854,6 @@ msgstr "検証する"
 #: src/components/verify.tsx:73
 msgid "Verification code mismatch."
 msgstr "検証コードが一致しません。"
-
-#: src/components/verify.tsx:75
-msgid "User not found. Please check entered username."
-msgstr "ユーザーが見つかりませんでした。ユーザー名を確認してください。"
 
 #: src/components/verify.tsx:86
 msgid "Verify your account"

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -156,20 +156,39 @@ msgid_plural "%s features have been added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/ForgotPassword.tsx:53
+#: src/components/ForgotPassword.tsx:48
+#: src/components/verify.tsx:75
+msgid "User not found. Please check entered username."
+msgstr ""
+
+#: src/components/ForgotPassword.tsx:54
+msgid "Cannot reset password for the user as there is no verified email."
+msgstr ""
+
+#: src/components/ForgotPassword.tsx:59
+msgid "Attempt limit exceeded, please try after some time."
+msgstr ""
+
+#: src/components/ForgotPassword.tsx:61
+#: src/components/Signin.tsx:96
+#: src/constants.ts:17
+msgid "Unknown error."
+msgstr ""
+
+#: src/components/ForgotPassword.tsx:73
 msgid "Reset your password"
 msgstr ""
 
-#: src/components/ForgotPassword.tsx:57
-#: src/components/Signin.tsx:126
-msgid "Username or email address"
+#: src/components/ForgotPassword.tsx:77
+#: src/components/Signup.tsx:110
+msgid "Email address"
 msgstr ""
 
-#: src/components/ForgotPassword.tsx:65
+#: src/components/ForgotPassword.tsx:85
 msgid "We will send you a verification code to reset your password."
 msgstr ""
 
-#: src/components/ForgotPassword.tsx:75
+#: src/components/ForgotPassword.tsx:95
 msgid "Send password reset email"
 msgstr ""
 
@@ -396,6 +415,10 @@ msgstr ""
 msgid "Oops, the server seems not to be responding correctly."
 msgstr ""
 
+#: src/components/Signin.tsx:126
+msgid "Username or email address"
+msgstr ""
+
 #: src/components/Signin.tsx:150
 msgid "Forgot password?"
 msgstr ""
@@ -416,17 +439,8 @@ msgstr ""
 msgid "Incorrect username, email address or password."
 msgstr ""
 
-#: src/components/Signin.tsx:96
-#: src/constants.ts:17
-msgid "Unknown error."
-msgstr ""
-
 #: src/components/Signup.tsx:106
 msgid "Username cannot be modified later."
-msgstr ""
-
-#: src/components/Signup.tsx:110
-msgid "Email address"
 msgstr ""
 
 #: src/components/Signup.tsx:130
@@ -824,10 +838,6 @@ msgstr ""
 
 #: src/components/verify.tsx:73
 msgid "Verification code mismatch."
-msgstr ""
-
-#: src/components/verify.tsx:75
-msgid "User not found. Please check entered username."
 msgstr ""
 
 #: src/components/verify.tsx:86


### PR DESCRIPTION
パスワード紛失フォームのエラーハンドリングとメッセージの追加です。

<img width="479" alt="Screenshot 2020-03-30 22 52 21" src="https://user-images.githubusercontent.com/6292312/77920450-75520280-72d9-11ea-8408-9adfec19e923.png">
<img width="450" alt="Screenshot 2020-03-30 22 52 28" src="https://user-images.githubusercontent.com/6292312/77920456-784cf300-72d9-11ea-9b30-c9b8df70b924.png">
<img width="453" alt="Screenshot 2020-03-30 22 53 14" src="https://user-images.githubusercontent.com/6292312/77920458-797e2000-72d9-11ea-90c5-82cc393d8ac4.png">
