### PR TITLE
ダウンロードボタンはドラフト状態の時は不活化

### DIFF
--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -269,6 +269,7 @@ const Content = (props: Props & StateProps) => {
               size="large"
               style={{ width: "100%" }}
               href={`https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/pub/${geojsonId}`}
+              disabled={status === "draft"}
             >
               {__("Download")}
             </Button>


### PR DESCRIPTION
サーバー側では 404 を返すように対応
https://github.com/geolonia/api.geolonia.com/pull/121