### PR TITLE
Mapbox Draw のイベントハンドラがレンダー時に置き換えるように修正

### DIFF
--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -390,7 +390,7 @@ const Content = (props: Props) => {
           getNumberFeatures={getNumberFeatures}
           geoJSON={geoJSON}
           onClickFeature={onClickFeatureHandler}
-          saveCallback={(event: any) => saveFeatureCallback(event)}
+          saveCallback={saveFeatureCallback}
           bounds={bounds}
         />
         {currentFeature ? (

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -84,7 +84,7 @@ const Content = (props: Props) => {
   );
 
   // send web socket message to notify team members
-  const publish = (featureId: string) => {
+  const publish = (featureId = "") => {
     if (socket) {
       socket.send(
         JSON.stringify({
@@ -240,16 +240,12 @@ const Content = (props: Props) => {
 
   /**
    * Fires when a feature will be created, updated, deleted.
-   * TODO: WebSocket でメッセージを送信できない。これは GeoJSON をクライアント側で更新しても子コンポーネントが render されず、古い public の古い参照を保持し続けているため。
-   * リファクタリングしてReact のライフサイクルに合わせる必要がある。
    * @param event
    */
   const saveFeatureCallback = (event: any) => {
     if ("draw.delete" === event.type) {
       setCurrentFeature(undefined); // Set undefined to currentFeature
-    }
-
-    if ("draw.create" === event.type) {
+    } else if ("draw.create" === event.type) {
       fetch(
         props.session,
         `https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/${props.geojsonId}/features`,
@@ -257,7 +253,7 @@ const Content = (props: Props) => {
           method: "POST",
           body: JSON.stringify(event.features)
         }
-      ).then(() => publish(""));
+      ).then(() => publish());
     } else if ("draw.update" === event.type) {
       event.features.forEach((feature: GeoJSON.Feature) => {
         return fetch(
@@ -267,7 +263,9 @@ const Content = (props: Props) => {
             method: "PUT",
             body: JSON.stringify(feature)
           }
-        ).then(() => publish(""));
+        ).then(() => {
+          publish();
+        });
       });
     } else if ("draw.delete" === event.type) {
       Promise.all(
@@ -282,7 +280,7 @@ const Content = (props: Props) => {
           );
         })
       ).then(() => {
-        publish("");
+        publish();
       });
     }
   };
@@ -311,7 +309,7 @@ const Content = (props: Props) => {
         method: "POST",
         body: JSON.stringify(all.features)
       }
-    ).then(() => publish(""));
+    ).then(() => publish());
   };
 
   const getNumberFeatures = () => {

--- a/src/components/Data/MapEditor.tsx
+++ b/src/components/Data/MapEditor.tsx
@@ -5,14 +5,11 @@ import jsonStyle from "../custom/drawStyle";
 import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
 import { _x } from "@wordpress/i18n";
 import fullscreen from "./fullscreenMap";
-import { connect } from "react-redux";
 
 // @ts-ignore
 import centroid from "@turf/centroid";
 // @ts-ignore
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
-
-import { AppState, Session } from "../../types";
 
 type OwnProps = {
   geoJSON: GeoJSON.FeatureCollection | undefined;
@@ -24,12 +21,7 @@ type OwnProps = {
   style: string;
 };
 
-type StateProps = {
-  session: Session;
-  teamId?: string;
-};
-
-type Props = OwnProps & StateProps;
+type Props = OwnProps;
 
 const mapStyle: React.CSSProperties = {
   width: "100%",
@@ -46,9 +38,7 @@ export const MapEditor = (props: Props) => {
     saveCallback,
     getNumberFeatures,
     bounds,
-    style,
-    session,
-    teamId
+    style
   } = props;
 
   // mapbox map and draw binding
@@ -148,12 +138,4 @@ export const MapEditor = (props: Props) => {
   );
 };
 
-const mapStateToProps = (state: AppState): StateProps => {
-  const team = state.team.data[state.team.selectedIndex];
-  return {
-    session: state.authSupport.session,
-    teamId: team && team.teamId
-  };
-};
-
-export default connect(mapStateToProps)(MapEditor);
+export default MapEditor;

--- a/src/components/Data/MapEditor.tsx
+++ b/src/components/Data/MapEditor.tsx
@@ -30,20 +30,29 @@ const mapStyle: React.CSSProperties = {
   margin: "0 0 1em 0"
 };
 
+const createMapEvents = (props: Props, map: mapboxgl.Map) => {
+  return {
+    selectionChange: (event: any) => {
+      if (event.features.length) {
+        const center = centroid(event.features[0]);
+        map.setCenter(center.geometry.coordinates);
+      }
+      props.onClickFeature(event);
+    },
+    drawUpdate: (event: any) => {
+      props.getNumberFeatures();
+      props.saveCallback(event);
+    }
+  };
+};
+
 export const MapEditor = (props: Props) => {
-  const {
-    geoJSON,
-    onClickFeature,
-    drawCallback,
-    saveCallback,
-    getNumberFeatures,
-    bounds,
-    style
-  } = props;
+  const { geoJSON, drawCallback, getNumberFeatures, bounds, style } = props;
 
   // mapbox map and draw binding
   const [map, setMap] = React.useState<mapboxgl.Map | undefined>(undefined);
   const [draw, setDraw] = React.useState<MapboxDraw | undefined>(undefined);
+  const [events, setEvents] = React.useState<any>(null);
 
   // import geoJSON
   React.useEffect(() => {
@@ -93,30 +102,29 @@ export const MapEditor = (props: Props) => {
     setDraw(draw);
     setMap(map);
 
-    map.on("draw.selectionchange", (event: any) => {
-      if (event.features.length) {
-        const center = centroid(event.features[0]);
-        map.setCenter(center.geometry.coordinates);
-      }
-
-      onClickFeature(event);
-    });
-
-    map.on("draw.create", (event: any) => {
-      getNumberFeatures();
-      saveCallback(event);
-    });
-
-    map.on("draw.delete", (event: any) => {
-      getNumberFeatures();
-      saveCallback(event);
-    });
-
-    map.on("draw.update", (event: any) => {
-      getNumberFeatures();
-      saveCallback(event);
-    });
+    const mapEvents = createMapEvents(props, map);
+    map.on("draw.selectionchange", mapEvents.selectionChange);
+    map.on("draw.create", mapEvents.drawUpdate);
+    map.on("draw.delete", mapEvents.drawUpdate);
+    map.on("draw.update", mapEvents.drawUpdate);
+    setEvents(mapEvents);
   };
+
+  React.useEffect(() => {
+    if (map && events) {
+      map.off("draw.selectionchange", events.selectionChange);
+      map.off("draw.create", events.drawUpdate);
+      map.off("draw.delete", events.drawUpdate);
+      map.off("draw.update", events.drawUpdate);
+      const nextEvents = createMapEvents(props, map);
+      map.on("draw.selectionchange", nextEvents.selectionChange);
+      map.on("draw.create", nextEvents.drawUpdate);
+      map.on("draw.delete", nextEvents.drawUpdate);
+      map.on("draw.update", nextEvents.drawUpdate);
+      setEvents(nextEvents);
+    }
+    // eslint-disable-next-line
+  }, [props]);
 
   return (
     <div style={mapStyle}>


### PR DESCRIPTION
新しい Props を与えた時に、 Mapbox Draw の `draw.create` などのイベントハンドラが更新される必要があったので、その Effect を追加しました。