### PR TITLE
GeoJSON の公開エンドポイントに関する UI の修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5758,8 +5758,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },
@@ -8947,9 +8946,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.3.tgz",
-      "integrity": "sha512-HyaFeyfTa18nYjft59vEPsvuq6ZVcrCC1rBw6Fx8ZV9NcuUITBNCnTOyr0tHHkkHn//d+lzhsL1YybgtLQ7lng=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "events": {
       "version": "3.1.0",
@@ -9267,8 +9266,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },
@@ -9498,22 +9496,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "requires": {
-        "debug": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
+      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -10350,9 +10335,9 @@
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -16989,8 +16974,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "resolved": ""
         }
       }
     },

--- a/src/auth/container.tsx
+++ b/src/auth/container.tsx
@@ -12,7 +12,6 @@ import listKeys from "../api/keys/list";
 import listTeamMembers from "../api/members/list";
 
 // Utils
-import delay from "../lib/promise-delay";
 import dateParse from "../lib/date-parse";
 import estimateLanguage from "../lib/estimate-language";
 

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -59,7 +59,7 @@ type RouterProps = {
 type Props = OwnProps & RouterProps & StateProps;
 
 const Content = (props: Props) => {
-  const [message, setMessage] = React.useState("");
+  const [message] = React.useState("");
   const [currentFeature, setCurrentFeature] = React.useState<
     Feature | undefined
   >();

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -95,7 +95,7 @@ const usePublic = (
         .catch(() => {
           // 意図せずリクエストが失敗している
           // 元に戻す
-          setDraftIsPublic(isPublic)
+          setDraftIsPublic(isPublic);
         });
     }
   }, [
@@ -266,51 +266,53 @@ const Content = (props: Props & StateProps) => {
       <Grid item sm={8} xs={12}>
         <Paper className="geojson-title-description">
           <h3>{__("Download GeoJSON")}</h3>
+          <input
+            disabled={!isPublic}
+            className="geolonia-geojson-api-endpoint"
+            value={`https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/pub/${geojsonId}`}
+          />
           <p>
             <Button
               variant="contained"
               color="primary"
               size="large"
               style={{ width: "100%" }}
-              href={`https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/pub/${geojsonId}`}
-              disabled={status === "draft"}
+              onClick={() => {
+                window
+                  .fetch(
+                    `https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/pub/${geojsonId}`
+                  )
+                  .then(res => {
+                    if (res.status < 400) {
+                      return res.json();
+                    } else {
+                      throw new Error("");
+                    }
+                  })
+                  .then(geojson => {
+                    const element = document.createElement("a");
+                    const file = new Blob([geojson], { type: "text/plain" });
+                    element.href = URL.createObjectURL(file);
+                    element.download = `${geojsonId}.geojson`;
+                    document.body.appendChild(element); // Required for this to work in FireFox
+                    element.click();
+                    document.body.removeChild(element);
+                  });
+              }}
+              disabled={status === "draft" || !isPublic}
             >
               {__("Download")}
             </Button>
           </p>
-        </Paper>
-
-        <Paper className="geojson-title-description">
-          <h3>{__("Private Endpoint")}</h3>
-          <>
-            <input
-              disabled={isPublic}
-              className="geolonia-geojson-api-endpoint"
-              value={`https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/private/${geojsonId}`}
-            />
-            <p>
-              <Button
-                disabled={isPublic}
-                variant="contained"
-                color="primary"
-                size="large"
-                style={{ width: "100%" }}
-                onClick={() => copyToClipBoard(props.style)}
-              >
-                {__("Copy embed code to clipboard")}
-              </Button>
+          {isPublic && (
+            <p style={{ textAlign: "center", fontSize: "90%" }}>
+              {__("Or")}
+              <br />
+              <button className="copy-button" onClick={copyUrlToClipBoard}>
+                {__("Copy endpoint URL to clipboard")}
+              </button>
             </p>
-            {!isPublic ? (
-              <p style={{ textAlign: "center", fontSize: "90%" }}>
-                {__("Or")}
-                <br />
-
-                <button className="copy-button" onClick={copyUrlToClipBoard}>
-                  {__("Copy endpoint URL to clipboard")}
-                </button>
-              </p>
-            ) : null}
-          </>
+          )}
         </Paper>
       </Grid>
     </Grid>

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -44,17 +44,17 @@ type Props = {
 
 type StateProps = { session: Session };
 
-const copyToClipBoard = (style: string) => {
-  const input = document.querySelector(
-    ".geolonia-geojson-api-endpoint"
-  ) as HTMLInputElement;
-  if (input) {
-    input.select();
-    clipboard.writeText(
-      `<div class="geolonia" data-geojson="${input.value}" style="${style}"></div>`
-    );
-  }
-};
+// const copyToClipBoard = (style: string) => {
+//   const input = document.querySelector(
+//     ".geolonia-geojson-api-endpoint"
+//   ) as HTMLInputElement;
+//   if (input) {
+//     input.select();
+//     clipboard.writeText(
+//       `<div class="geolonia" data-geojson="${input.value}" style="${style}"></div>`
+//     );
+//   }
+// };
 
 const copyUrlToClipBoard = () => {
   const input = document.querySelector(

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -184,7 +184,7 @@ const Content = (props: Props & StateProps) => {
     <Grid className="geojson-meta" container spacing={2}>
       <Grid item sm={4} xs={12}>
         <Paper className="geojson-title-description">
-          <div>
+          {/* <div>
             <Switch
               checked={draftIsPublic}
               onChange={e => {
@@ -205,7 +205,7 @@ const Content = (props: Props & StateProps) => {
                 Private
               </span>
             )}
-          </div>
+          </div> */}
           <div>
             {isPublic ? (
               <p>{__("Anyone can access this GeoJSON API.")}</p>

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -184,7 +184,7 @@ const Content = (props: Props & StateProps) => {
     <Grid className="geojson-meta" container spacing={2}>
       <Grid item sm={4} xs={12}>
         <Paper className="geojson-title-description">
-          {/* <div>
+          <div>
             <Switch
               checked={draftIsPublic}
               onChange={e => {
@@ -205,7 +205,7 @@ const Content = (props: Props & StateProps) => {
                 Private
               </span>
             )}
-          </div> */}
+          </div>
           <div>
             {isPublic ? (
               <p>{__("Anyone can access this GeoJSON API.")}</p>
@@ -284,19 +284,21 @@ const Content = (props: Props & StateProps) => {
                   )
                   .then(res => {
                     if (res.status < 400) {
-                      return res.json();
+                      return res.text();
                     } else {
                       throw new Error("");
                     }
                   })
-                  .then(geojson => {
+                  .then(geojsonString => {
                     const element = document.createElement("a");
-                    const file = new Blob([geojson], { type: "text/plain" });
+                    const file = new Blob([geojsonString], { type: "application/geo+json" });
                     element.href = URL.createObjectURL(file);
                     element.download = `${geojsonId}.geojson`;
                     document.body.appendChild(element); // Required for this to work in FireFox
                     element.click();
                     document.body.removeChild(element);
+                  }).catch(err => {
+                    //
                   });
               }}
               disabled={status === "draft" || !isPublic}

--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -33,53 +33,6 @@ const StripeContainer = (props: { children: React.ReactNode }) => {
   return <Elements stripe={stripePromise}>{props.children}</Elements>;
 };
 
-const chartStyle: React.CSSProperties = {
-  width: "100%",
-  height: "250px",
-  margin: "2em 0"
-};
-
-const chartData = {
-  labels: [
-    "Oct",
-    "Nov",
-    "Dec",
-    "Jan, 2019",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep"
-  ],
-  datasets: [
-    {
-      borderColor: "rgba(0, 149, 221, 1)",
-      backgroundColor: "rgba(0, 149, 221, 0.2)",
-      data: [400, 500, 300, 456, 500, 700, 720, 710, 800, 910, 1000, 110]
-    }
-  ]
-};
-
-const chartOptions = {
-  legend: {
-    display: false
-  },
-  maintainAspectRatio: false,
-  responsive: true,
-  scales: {
-    yAxes: [
-      {
-        ticks: {
-          min: 0
-        }
-      }
-    ]
-  }
-};
-
 type StateProps = {
   session: Session;
   last2?: string;

--- a/src/components/Team/plan-modal.tsx
+++ b/src/components/Team/plan-modal.tsx
@@ -41,7 +41,7 @@ const { REACT_APP_STAGE } = process.env;
 const PlanModal = (props: Props) => {
   const { open, handleClose, session, teamId, plans, currentPlanId } = props;
   const [loading, setLoading] = React.useState(false);
-  const [message, setMessage] = React.useState("");
+  const [message] = React.useState("");
   const [planId, setPlanId] = React.useState<string | null | undefined>(void 0);
 
   const handleSubmit = async () => {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -61,16 +61,14 @@
       "You can restrict the URLs that can use this GeoJSON API.": [
         "この GeoJSON API を利用できる URL を制限することができます。"
       ],
-      "Datasets are published now.": [""],
-      "Datasets status are draft now.": [""],
+      "Datasets are published now.": ["データセットは公開されています。"],
+      "Datasets status are draft now.": ["データセットは下書きの状態です。"],
       "Upgrade to Geolonia Team": ["チーム機能をアップグレード"],
       "Name": ["名前"],
-      "Name of public GeoJSON will be displayed in public.": [""],
-      "Download": ["GeoJSON をダウンロード"],
-      "Private Endpoint": ["プライベートエンドポイント"],
-      "Copy embed code to clipboard": [
-        "埋め込み用コードをクリップボードにコピー"
+      "Name of public GeoJSON will be displayed in public.": [
+        "公開されているGeoJSONの名前が表示されます。"
       ],
+      "Download": ["GeoJSON をダウンロード"],
       "Or": ["または"],
       "Copy endpoint URL to clipboard": [
         "エンドポイント URL をクリップボードにコピー"
@@ -244,14 +242,13 @@
       "You can see subscriptions for this team in this month.": [
         "このチームの今月のサブスクリプションを確認することができます。"
       ],
-      "Geolonia Appliance": ["Geolonia アプライアンス"],
-      "Contact us": ["お問い合わせ下さい"],
       "Payment information": ["支払い情報"],
       "Payment method:": ["支払い方法"],
       "ending in **%1$s": ["末尾の番号 **%1$s"],
       "Change payment method": ["支払い方法を変更"],
       "Current Plan": ["現在のプラン"],
       "Change Plan": ["プランを変更"],
+      "Paid invoice receipts": [""],
       "Upload new picture": ["新しい写真をアップロード"],
       "Upload failed. The avatar image size cannot be larger than %d MB.": [
         "アップロードに失敗しました。アバターの画像サイズの上限は %d MB です。"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -53,7 +53,7 @@ msgstr "GeoJSON をダウンロード"
 
 #: src/components/Data/GeoJson.tsx:106 src/components/Data/GeoJsons.tsx:119
 #: src/components/Maps/APIKey.tsx:112 src/components/Maps/APIKeys.tsx:38
-#: src/components/Team/Billing.tsx:177
+#: src/components/Team/Billing.tsx:175
 msgid "Home"
 msgstr ""
 
@@ -138,11 +138,11 @@ msgstr "この GeoJSON API を利用できる URL を制限することができ
 
 #: src/components/Data/GeoJsonMeta.tsx:241
 msgid "Datasets are published now."
-msgstr ""
+msgstr "データセットは公開されています。"
 
 #: src/components/Data/GeoJsonMeta.tsx:243
 msgid "Datasets status are draft now."
-msgstr ""
+msgstr "データセットは下書きの状態です。"
 
 #: src/components/Data/GeoJsonMeta.tsx:246
 msgid "Upgrade to Geolonia Team"
@@ -158,25 +158,17 @@ msgstr "名前"
 
 #: src/components/Data/GeoJsonMeta.tsx:263
 msgid "Name of public GeoJSON will be displayed in public."
-msgstr ""
+msgstr "公開されているGeoJSONの名前が表示されます。"
 
-#: src/components/Data/GeoJsonMeta.tsx:278
+#: src/components/Data/GeoJsonMeta.tsx:306
 msgid "Download"
 msgstr "GeoJSON をダウンロード"
 
-#: src/components/Data/GeoJsonMeta.tsx:284
-msgid "Private Endpoint"
-msgstr "プライベートエンドポイント"
-
-#: src/components/Data/GeoJsonMeta.tsx:300
-msgid "Copy embed code to clipboard"
-msgstr "埋め込み用コードをクリップボードにコピー"
-
-#: src/components/Data/GeoJsonMeta.tsx:305
+#: src/components/Data/GeoJsonMeta.tsx:311
 msgid "Or"
 msgstr "または"
 
-#: src/components/Data/GeoJsonMeta.tsx:309
+#: src/components/Data/GeoJsonMeta.tsx:314
 msgid "Copy endpoint URL to clipboard"
 msgstr "エンドポイント URL をクリップボードにコピー"
 
@@ -660,50 +652,46 @@ msgid "We are currently private beta. Sign Up is restricted to invited users."
 msgstr ""
 "現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。"
 
-#: src/components/Team/Billing.tsx:155
+#: src/components/Team/Billing.tsx:153
 msgid "Free plan"
 msgstr "フリープラン"
 
-#: src/components/Team/Billing.tsx:181 src/components/Team/general/index.tsx:31
+#: src/components/Team/Billing.tsx:179 src/components/Team/general/index.tsx:31
 #: src/components/Team/members/index.tsx:126
 msgid "Team settings"
 msgstr "チーム設定"
 
-#: src/components/Team/Billing.tsx:190
+#: src/components/Team/Billing.tsx:188
 msgid "You can see subscriptions for this team in this month."
 msgstr "このチームの今月のサブスクリプションを確認することができます。"
 
-#: src/components/Team/Billing.tsx:249
-msgid "Geolonia Appliance"
-msgstr "Geolonia アプライアンス"
-
-#: src/components/Team/Billing.tsx:262
-msgid "Contact us"
-msgstr "お問い合わせ下さい"
-
-#: src/components/Team/Billing.tsx:346
+#: src/components/Team/Billing.tsx:195
 msgid "Payment information"
 msgstr "支払い情報"
 
-#: src/components/Team/Billing.tsx:352
+#: src/components/Team/Billing.tsx:201
 msgid "Payment method:"
 msgstr "支払い方法"
 
-#: src/components/Team/Billing.tsx:356
+#: src/components/Team/Billing.tsx:205
 msgid "ending in **%1$s"
 msgstr "末尾の番号 **%1$s"
 
-#: src/components/Team/Billing.tsx:366
+#: src/components/Team/Billing.tsx:215
 msgid "Change payment method"
 msgstr "支払い方法を変更"
 
-#: src/components/Team/Billing.tsx:376
+#: src/components/Team/Billing.tsx:225
 msgid "Current Plan"
 msgstr "現在のプラン"
 
-#: src/components/Team/Billing.tsx:387
+#: src/components/Team/Billing.tsx:236
 msgid "Change Plan"
 msgstr "プランを変更"
+
+#: src/components/Team/Billing.tsx:266
+msgid "Paid invoice receipts"
+msgstr ""
 
 #: src/components/Team/general/avatar.tsx:126
 #: src/components/User/avatar.tsx:133
@@ -1161,6 +1149,18 @@ msgstr "139.74135747222223"
 msgctxt "Default value of zoom level of map"
 msgid "0"
 msgstr "6"
+
+#~ msgid "Private Endpoint"
+#~ msgstr "プライベートエンドポイント"
+
+#~ msgid "Copy embed code to clipboard"
+#~ msgstr "埋め込み用コードをクリップボードにコピー"
+
+#~ msgid "Geolonia Appliance"
+#~ msgstr "Geolonia アプライアンス"
+
+#~ msgid "Contact us"
+#~ msgstr "お問い合わせ下さい"
 
 #~ msgid "Payment history"
 #~ msgstr "支払履歴"

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -46,7 +46,7 @@ msgstr ""
 #: src/components/Data/GeoJsons.tsx:119
 #: src/components/Maps/APIKey.tsx:112
 #: src/components/Maps/APIKeys.tsx:38
-#: src/components/Team/Billing.tsx:177
+#: src/components/Team/Billing.tsx:175
 msgid "Home"
 msgstr ""
 
@@ -153,23 +153,15 @@ msgstr ""
 msgid "Name of public GeoJSON will be displayed in public."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:278
+#: src/components/Data/GeoJsonMeta.tsx:306
 msgid "Download"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:284
-msgid "Private Endpoint"
-msgstr ""
-
-#: src/components/Data/GeoJsonMeta.tsx:300
-msgid "Copy embed code to clipboard"
-msgstr ""
-
-#: src/components/Data/GeoJsonMeta.tsx:305
+#: src/components/Data/GeoJsonMeta.tsx:311
 msgid "Or"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:309
+#: src/components/Data/GeoJsonMeta.tsx:314
 msgid "Copy endpoint URL to clipboard"
 msgstr ""
 
@@ -647,50 +639,46 @@ msgstr ""
 msgid "We are currently private beta. Sign Up is restricted to invited users."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:155
+#: src/components/Team/Billing.tsx:153
 msgid "Free plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:181
+#: src/components/Team/Billing.tsx:179
 #: src/components/Team/general/index.tsx:31
 #: src/components/Team/members/index.tsx:126
 msgid "Team settings"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:190
+#: src/components/Team/Billing.tsx:188
 msgid "You can see subscriptions for this team in this month."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:249
-msgid "Geolonia Appliance"
-msgstr ""
-
-#: src/components/Team/Billing.tsx:262
-msgid "Contact us"
-msgstr ""
-
-#: src/components/Team/Billing.tsx:346
+#: src/components/Team/Billing.tsx:195
 msgid "Payment information"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:352
+#: src/components/Team/Billing.tsx:201
 msgid "Payment method:"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:356
+#: src/components/Team/Billing.tsx:205
 msgid "ending in **%1$s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:366
+#: src/components/Team/Billing.tsx:215
 msgid "Change payment method"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:376
+#: src/components/Team/Billing.tsx:225
 msgid "Current Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:387
+#: src/components/Team/Billing.tsx:236
 msgid "Change Plan"
+msgstr ""
+
+#: src/components/Team/Billing.tsx:266
+msgid "Paid invoice receipts"
 msgstr ""
 
 #: src/components/Team/general/avatar.tsx:126


### PR DESCRIPTION
- File API 経由でダウンロードするボタンの追加
- URL をコピー可能に変更
- プライベートなエンドポイントは一旦削除

<img width="658" alt="Screen Shot 2020-06-19 at 19 48 14" src="https://user-images.githubusercontent.com/6292312/85125211-2bd4dc00-b266-11ea-840b-dc5aee047378.png">
