### PR TITLE
サインイン・サインアップ時の言語のハンドリング

### DIFF
--- a/src/auth/container.tsx
+++ b/src/auth/container.tsx
@@ -112,6 +112,10 @@ export class AuthContainer extends React.Component<Props, State> {
         throw new Error("invalid user meta response");
       }
 
+      if (user.language) {
+        localStorage.setItem("geolonia__persisted_language", user.language);
+      }
+
       if (teams.some(team => !isTeam(team))) {
         throw new Error("invalid team response");
       }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -154,7 +154,25 @@ export const signout = () =>
     if (cognitoUser) {
       cognitoUser.signOut();
     }
+
+    // Persists `geolonia__persisted*` items
+    // e.g. `geolonia__persisted_language` will be used at signin page without session
+    const thePersisted = Object.keys(localStorage)
+      .filter(key => key.indexOf("geolonia__persisted") === 0)
+      .reduce<{ [key: string]: string }>((prev, key) => {
+        const value = localStorage.getItem(key);
+        if (value) {
+          prev[key] = value;
+        }
+        return prev;
+      }, {});
+
     localStorage.clear();
+
+    Object.keys(thePersisted).forEach(key => {
+      const value = thePersisted[key];
+      localStorage.setItem(key, value);
+    });
     resolve();
   });
 

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -2,6 +2,7 @@
 
 import "isomorphic-fetch";
 import * as CognitoIdentity from "amazon-cognito-identity-js";
+import queryString from "query-string";
 
 const {
   REACT_APP_COGNITO_USERPOOL_ID: UserPoolId,
@@ -15,8 +16,11 @@ const userPool = new CognitoIdentity.CognitoUserPool(poolData);
 
 export const signUp = (username: string, email: string, password: string) =>
   new Promise<CognitoIdentity.ISignUpResult>((resolve, reject) => {
-    // TODO: if we have more language option, let's extend
-    const language = navigator.language.slice(0, 2) === "ja" ? "ja" : "en";
+    // NOTE: if we have more language option, let's extend
+    const parsed = queryString.parse(window.location.search);
+    const urlLang = parsed.lang;
+    const language =
+      typeof urlLang === "string" && urlLang !== "" ? urlLang : "ja";
     const attributeList = [
       new CognitoIdentity.CognitoUserAttribute({ Name: "email", Value: email }),
       new CognitoIdentity.CognitoUserAttribute({

--- a/src/components/DeveloperBlog.tsx
+++ b/src/components/DeveloperBlog.tsx
@@ -9,7 +9,7 @@ import CardMedia from '@material-ui/core/CardMedia';
 import Typography from '@material-ui/core/Typography';
 
 type BlogPost = {
-  id : string;
+  id: string;
   url: string;
   title: string;
   excerpt: string;

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -42,7 +42,7 @@ type DispatchProps = {
 };
 type Props = OwnProps & RouterProps & StateProps & DispatchProps;
 
-const Content = (props: Props) => {
+const Signin = (props: Props) => {
   const { serverTrouble } = props;
 
   const [username, setUsername] = React.useState("");
@@ -168,7 +168,7 @@ const Content = (props: Props) => {
         </form>
 
         <p>
-          {__("New to Geolonia?")}
+          {__("New to Geolonia?")}{" "}
           <Link href="#/signup" tabIndex={500}>
             {__("Create an account.")}
           </Link>
@@ -189,6 +189,6 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch) => ({
   setAccessToken: (accessToken: string) =>
     dispatch(createActions.setAccessToken(accessToken))
 });
-const ConnectedContent = connect(mapStateToProps, mapDispatchToProps)(Content);
+const ConnectedContent = connect(mapStateToProps, mapDispatchToProps)(Signin);
 
 export default ConnectedContent;

--- a/src/components/custom/languages.tsx
+++ b/src/components/custom/languages.tsx
@@ -6,7 +6,7 @@ import { __ } from "@wordpress/i18n";
 type Languages = {
   [key: string]: { primitive: string; translated: string };
 };
-const Content = () => {
+const Languages = () => {
   const hash = window.location.hash;
   const estimatedLanguage = estimateLanguage();
 
@@ -28,7 +28,12 @@ const Content = () => {
               {estimatedLanguage === key ? (
                 <span>{languages[key].translated}</span>
               ) : (
-                <Link href={`/?lang=${key}${hash}`}>
+                <Link
+                  href={`/?lang=${key}${hash}`}
+                  onClick={() => {
+                    localStorage.setItem("geolonia__persisted_language", key);
+                  }}
+                >
                   {languages[key].primitive}
                 </Link>
               )}
@@ -40,4 +45,4 @@ const Content = () => {
   );
 };
 
-export default Content;
+export default Languages;

--- a/src/lib/estimate-language.ts
+++ b/src/lib/estimate-language.ts
@@ -1,9 +1,18 @@
 import queryString from "query-string";
 
 export default () => {
-  const browserLanguage = navigator.language.slice(0, 2) === "ja" ? "ja" : "en";
   const parsed = queryString.parse(window.location.search);
-  const urlLanguage =
+  const qsLang =
     parsed && typeof parsed.lang === "string" ? parsed.lang : void 0;
-  return urlLanguage || browserLanguage;
+  if (qsLang) {
+    return qsLang;
+  }
+
+  const persistedLang = localStorage.getItem("geolonia__persisted_language");
+  if (persistedLang) {
+    return persistedLang;
+  }
+
+  const browserLang = navigator.language.slice(0, 2) === "ja" ? "ja" : "en";
+  return browserLang;
 };

--- a/src/redux/middlewares/local-storage.ts
+++ b/src/redux/middlewares/local-storage.ts
@@ -2,7 +2,7 @@ import { Middleware } from "redux";
 import { isSelectAction } from "../actions/team";
 import { AppState } from "../../types";
 
-export const SELECTED_TEAM_ID_KEY = "geolonia__selectedTeamId";
+export const SELECTED_TEAM_ID_KEY = "geolonia__persisted_selectedTeamId";
 
 const localStorageMiddleware: Middleware = store => next => action => {
   if (isSelectAction(action)) {


### PR DESCRIPTION
~明示的に言語を選択する UI を以前追加していたため、それに追従しました。~
<img width="595" alt="Screen Shot 2020-06-20 at 10 54 43" src="https://user-images.githubusercontent.com/6292312/85188860-b9571100-b2e4-11ea-8dbc-2b9644d707d4.png">

~サインアップ後のデフォルトのダッシュボードの表示言語は、サインアップ時に表示していた画面の言語になります。~