### PR TITLE
サインアップ時の言語のハンドリングの堅牢化

### DIFF
--- a/src/auth/container.tsx
+++ b/src/auth/container.tsx
@@ -112,6 +112,8 @@ export class AuthContainer extends React.Component<Props, State> {
         throw new Error("invalid user meta response");
       }
 
+      // ログイン時に毎回ユーザーの言語をローカルストレージに保存しておく。
+      // ログアウトしたときの多言語化で使うため
       if (user.language) {
         localStorage.setItem("geolonia__persisted_language", user.language);
       }

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -16,17 +16,12 @@ const userPool = new CognitoIdentity.CognitoUserPool(poolData);
 
 export const signUp = (username: string, email: string, password: string) =>
   new Promise<CognitoIdentity.ISignUpResult>((resolve, reject) => {
-    const persistedLang = localStorage.getItem("geolonia__persisted_language");
-
     // NOTE: if we have more language option, let's extend
     const parsed = queryString.parse(window.location.search);
     const urlLang = parsed.lang;
 
-    const language = persistedLang
-      ? persistedLang
-      : typeof urlLang === "string" && urlLang !== ""
-      ? urlLang
-      : "ja";
+    const language =
+      typeof urlLang === "string" && urlLang !== "" ? urlLang : "ja";
 
     const attributeList = [
       new CognitoIdentity.CognitoUserAttribute({ Name: "email", Value: email }),

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -2,7 +2,7 @@
 
 import "isomorphic-fetch";
 import * as CognitoIdentity from "amazon-cognito-identity-js";
-import queryString from "query-string";
+import estimateLanguage from "../lib/estimate-language";
 
 const {
   REACT_APP_COGNITO_USERPOOL_ID: UserPoolId,
@@ -17,17 +17,12 @@ const userPool = new CognitoIdentity.CognitoUserPool(poolData);
 export const signUp = (username: string, email: string, password: string) =>
   new Promise<CognitoIdentity.ISignUpResult>((resolve, reject) => {
     // NOTE: if we have more language option, let's extend
-    const parsed = queryString.parse(window.location.search);
-    const urlLang = parsed.lang;
-
-    const language =
-      typeof urlLang === "string" && urlLang !== "" ? urlLang : "ja";
-
     const attributeList = [
       new CognitoIdentity.CognitoUserAttribute({ Name: "email", Value: email }),
       new CognitoIdentity.CognitoUserAttribute({
         Name: "locale",
-        Value: language
+        // 今使っている言語を送信する
+        Value: estimateLanguage()
       })
     ];
 

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -16,11 +16,18 @@ const userPool = new CognitoIdentity.CognitoUserPool(poolData);
 
 export const signUp = (username: string, email: string, password: string) =>
   new Promise<CognitoIdentity.ISignUpResult>((resolve, reject) => {
+    const persistedLang = localStorage.getItem("geolonia__persisted_language");
+
     // NOTE: if we have more language option, let's extend
     const parsed = queryString.parse(window.location.search);
     const urlLang = parsed.lang;
-    const language =
-      typeof urlLang === "string" && urlLang !== "" ? urlLang : "ja";
+
+    const language = persistedLang
+      ? persistedLang
+      : typeof urlLang === "string" && urlLang !== ""
+      ? urlLang
+      : "ja";
+
     const attributeList = [
       new CognitoIdentity.CognitoUserAttribute({ Name: "email", Value: email }),
       new CognitoIdentity.CognitoUserAttribute({

--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -17,6 +17,7 @@ import Interweave from "interweave";
 import { parseSignupError as parseCognitoSignupError } from "../lib/cognito/parse-error";
 import estimateLanguage from "../lib/estimate-language";
 import { pageTransitionInterval } from "../constants";
+import queryString from "query-string";
 
 type OwnProps = {};
 type RouterProps = {
@@ -82,6 +83,17 @@ const Content = (props: Props) => {
     // enter
     e.keyCode === 13 && !buttonDisabled && handleSignup();
   };
+
+  // URL locale will be sent to UserPool. So serialize persisted locale at first
+  React.useEffect(() => {
+    const persistedLang = localStorage.getItem("geolonia__persisted_language");
+    if (persistedLang) {
+      const parsed = queryString.parse(window.location.search);
+      parsed.lang = persistedLang;
+      const newUrl = `/?${queryString.stringify(parsed)}/#/signup`;
+      window.history.pushState({ path: newUrl }, "", newUrl);
+    }
+  }, []);
 
   return (
     <div className="signup">

--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -86,13 +86,10 @@ const Content = (props: Props) => {
 
   // URL locale will be sent to UserPool. So serialize persisted locale at first
   React.useEffect(() => {
-    const persistedLang = localStorage.getItem("geolonia__persisted_language");
-    if (persistedLang) {
-      const parsed = queryString.parse(window.location.search);
-      parsed.lang = persistedLang;
-      const newUrl = `/?${queryString.stringify(parsed)}/#/signup`;
-      window.history.pushState({ path: newUrl }, "", newUrl);
-    }
+    const parsed = queryString.parse(window.location.search);
+    parsed.lang = estimateLanguage();
+    const newUrl = `/?${queryString.stringify(parsed)}#/signup`;
+    window.history.pushState({ path: newUrl }, "", newUrl);
   }, []);
 
   return (

--- a/src/lib/estimate-language.ts
+++ b/src/lib/estimate-language.ts
@@ -1,6 +1,7 @@
 import queryString from "query-string";
 
 export default () => {
+  // URL で明示される言語を優先
   const parsed = queryString.parse(window.location.search);
   const qsLang =
     parsed && typeof parsed.lang === "string" ? parsed.lang : void 0;
@@ -8,11 +9,13 @@ export default () => {
     return qsLang;
   }
 
+  // 次にローカルストレージに格納された暗黙の言語（ログアウトする前に使っていた言語）を優先
   const persistedLang = localStorage.getItem("geolonia__persisted_language");
   if (persistedLang) {
     return persistedLang;
   }
 
+  // 最後にブラウザの言語を優先
   const browserLang = navigator.language.slice(0, 2) === "ja" ? "ja" : "en";
   return browserLang;
 };


### PR DESCRIPTION
#314 でサインアップした画面の言語設定と別の言語設定を送ってしまうケースがあったので修正しました。
サインインしていない時、言語設定はURL とlocalStorage の場所で保存されうるのですが、そこから言語設定を取得する際の優先順位を固定しました。
