### PR TITLE
コードを再送するUIのユーザービリティ改善

### DIFF
--- a/src/components/resend-code.tsx
+++ b/src/components/resend-code.tsx
@@ -12,9 +12,13 @@ import { __ } from "@wordpress/i18n";
 import estimateLanguage from "../lib/estimate-language";
 import { pageTransitionInterval } from "../constants";
 import { parseResendError as parseCognitoResendError } from "../lib/cognito/parse-error";
+import queryString from "query-string";
 
-const Content = () => {
-  const [username, setUsername] = React.useState("");
+const ResendCode = () => {
+  const parsed = queryString.parse(window.location.search);
+  const qsusername = parsed.username as string;
+
+  const [username, setUsername] = React.useState(qsusername || "");
   const [status, setStatus] = React.useState<
     null | "requesting" | "success" | "warning"
   >(null);
@@ -84,4 +88,4 @@ const Content = () => {
   );
 };
 
-export default Content;
+export default ResendCode;

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -409,7 +409,7 @@
         "ユーザーが見つかりませんでした。ユーザー名を確認してください。"
       ],
       "User not found. Please check entered username or email. If you use email, perhaps the email is not verified.": [
-        ""
+        "ユーザーが見つかりませんでした。ユーザー名またはメールアドレスを確認してください。メールアドレスが認証されていない可能性があります。"
       ],
       "Default value of latitude for map\u00040": ["35.65810422222222"],
       "Default value of longitude for map\u00040": ["139.74135747222223"],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -1133,7 +1133,7 @@ msgstr "ユーザーが見つかりませんでした。ユーザー名を確認
 msgid ""
 "User not found. Please check entered username or email. If you use email, "
 "perhaps the email is not verified."
-msgstr ""
+msgstr "ユーザーが見つかりませんでした。ユーザー名またはメールアドレスを確認してください。メールアドレスが認証されていない可能性があります。"
 
 #: src/components/Data/MapEditor.tsx:137
 msgctxt "Default value of latitude for map"


### PR DESCRIPTION
サインインに失敗した直後など、推定できる時はユーザー名を自動で埋めるようにしました。

<img width="360" alt="Screen Shot 2020-06-21 at 9 30 10" src="https://user-images.githubusercontent.com/6292312/85218132-4330d800-b3d2-11ea-9288-bd8cec9bb4bf.png">
