### PR TITLE
公開前修正

### DIFF
--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -75,7 +75,8 @@ const Content = (props: Props) => {
     geoJSON,
     setGeoJSON,
     setGeoJsonMeta,
-    setBounds
+    setBounds,
+    error
   } = useGeoJSON(props.session, props.geojsonId);
 
   const [socket, updateRequired, resetUpdateRequired] = useWebSocket(
@@ -319,6 +320,10 @@ const Content = (props: Props) => {
     }
   };
 
+  if (error) {
+    return <></>;
+  }
+
   return (
     <div className="gis-panel">
       <Title
@@ -431,7 +436,7 @@ const Content = (props: Props) => {
       >
         <Delete
           text1={__("Are you sure you want to delete this Dataset?")}
-          text2={__("Please type in the name of the Dataset to confirm.")}
+          text2={__("Please type delete to confirm.")}
           answer={geoJsonMeta ? geoJsonMeta.name : void 0}
           errorMessage={message}
           onClick={onDeleteClick}

--- a/src/components/Data/fields.tsx
+++ b/src/components/Data/fields.tsx
@@ -67,7 +67,7 @@ export const Fields = () => {
           onFailure={() => void 0}
           errorMessage={"some error"}
           text1={__("Are you sure you want to delete this dataset?")}
-          text2={__("Please type in the name of the dataset to confirm.")}
+          text2={__("Please type delete to confirm.")}
         />
       </div>
     </>

--- a/src/components/Maps/APIKey.tsx
+++ b/src/components/Maps/APIKey.tsx
@@ -271,15 +271,15 @@ const Content = (props: Props) => {
           >
             <Delete
               text1={__("Are you sure you want to delete this API key?")}
-              text2={__("Please type in the name of the API key to confirm.")}
+              text2={__("Please type delete to confirm.")}
               errorMessage={message}
               onClick={onDeleteClick}
               onFailure={onRequestError}
               // disable buttons before page move on success
               disableCancel={status => status === "success"}
-              disableDelete={(input, status) =>
-                input !== name || status === "success"
-              }
+              disableDelete={(input, status) => {
+                return input !== "delete" || status === "success";
+              }}
             />
           </DangerZone>
         </Grid>

--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -34,7 +34,7 @@ type Props = OwnProps & RouterProps & StateProps & DispatchProps;
 
 type Status = null | "requesting" | "success" | "warning";
 
-const Content = (props: Props) => {
+const Signup = (props: Props) => {
   const [username, setUsername] = React.useState("");
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
@@ -49,6 +49,9 @@ const Content = (props: Props) => {
     setStatus(null);
     setEmail(e.currentTarget.value);
   };
+  const onEmailBlur = (e: React.FormEvent<HTMLInputElement>) => {
+    setEmail(e.currentTarget.value.trim());
+  };
   const onPasswordChange = (e: React.FormEvent<HTMLInputElement>) => {
     setStatus(null);
     setPassword(e.currentTarget.value);
@@ -57,14 +60,15 @@ const Content = (props: Props) => {
   const handleSignup = (e: React.MouseEvent | void) => {
     e && e.preventDefault();
     setStatus("requesting");
+    setUsername(username);
     delay(signUp(username, email, password), 500)
       .then(result => {
         setStatus("success");
-        const username = result.user.getUsername();
-        props.setCurrentUser(username);
+        const succeededUsername = result.user.getUsername();
+        props.setCurrentUser(succeededUsername);
         setTimeout(() => {
           window.location.href = `/?lang=${estimateLanguage()}&username=${encodeURIComponent(
-            username
+            succeededUsername
           )}#/verify`;
         }, pageTransitionInterval);
       })
@@ -119,6 +123,7 @@ const Content = (props: Props) => {
               type={"text"}
               value={email}
               onChange={onEmailChange}
+              onBlur={onEmailBlur}
             />
           </label>
           <label className="password">
@@ -174,9 +179,8 @@ const mapStateToProps = (): StateProps => ({});
 const mapDispatchToProps = (dispatch: Redux.Dispatch): DispatchProps => ({
   setCurrentUser: (user: string) => dispatch(createActions.setCurrentUser(user))
 });
-const ConnectedContent = connect<StateProps, DispatchProps>(
+
+export default connect<StateProps, DispatchProps>(
   mapStateToProps,
   mapDispatchToProps
-)(Content);
-
-export default ConnectedContent;
+)(Signup);

--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -99,11 +99,6 @@ const Content = (props: Props) => {
         <img src={Logo} alt="" className="logo" />
         <h1>{__("Welcome to Geolonia")}</h1>
         <h2>{__("Create your account")}</h2>
-        <p>
-          {__(
-            "We are currently private beta. Sign Up is restricted to invited users."
-          )}
-        </p>
         <form className="form">
           <label className="username">
             <h3>{__("Username")}</h3>

--- a/src/components/Team/members/index.tsx
+++ b/src/components/Team/members/index.tsx
@@ -20,6 +20,7 @@ import ChangeRole from "./change-role";
 import Suspend from "./suspend";
 import RemoveMember from "./remove-member";
 import { Chip, Avatar } from "@material-ui/core";
+import Alert from "../../custom/Alert";
 
 // utils
 import { __ } from "@wordpress/i18n";
@@ -148,7 +149,13 @@ const Content = (props: Props) => {
     <div>
       <Title title="Members" breadcrumb={breadcrumbItems}>
         {__("You can manage members in your team.")}
+        <Alert type="danger">
+          {__(
+            "We are in public beta version. Member features will be added soon."
+          )}
+        </Alert>
       </Title>
+
       <Invite disabled={inviteDisabled} />
 
       {/* each member management */}

--- a/src/components/custom/Delete.tsx
+++ b/src/components/custom/Delete.tsx
@@ -141,7 +141,7 @@ export const Delete = (props: Props) => {
               onClick={onButtonClick}
               type="submit"
               disabled={
-                confirmation !== props.answer ||
+                confirmation !== "delete" ||
                 isDeleteDisabled ||
                 status === "working"
               }

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -48,7 +48,9 @@
       "Maximum upload file size: %d MB": [
         "最大アップロードファイルサイズ: %d MB"
       ],
-      "Existing feature that has same `id` will be updated.": [""],
+      "Existing feature that has same `id` will be updated.": [
+        "同じ `id` を持つ地物が更新されます。"
+      ],
       "Error: The name of identifier `id` must be lower case.": [
         "エラー: `id` は小文字である必要があります。"
       ],
@@ -214,9 +216,6 @@
       "Create an account.": ["アカウントを作成"],
       "Welcome to Geolonia": ["Geolonia へようこそ"],
       "Create your account": ["アカウントを作成"],
-      "We are currently private beta. Sign Up is restricted to invited users.": [
-        "現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。"
-      ],
       "Username": ["ユーザー名"],
       "Username cannot be modified later.": [
         "ユーザー名は後から変更できません。"
@@ -273,6 +272,9 @@
       "Save": ["保存"],
       "You can manage members in your team.": [
         "チームメンバーの管理ができます。"
+      ],
+      "We are in public beta version. Member features will be added soon.": [
+        "現在パブリックβ版です。メンバー機能は近日追加されます。"
       ],
       "Suspended": ["一時停止"],
       "rows per page": ["表示する個数"],
@@ -408,7 +410,7 @@
         "ユーザーが見つかりませんでした。ユーザー名を確認してください。"
       ],
       "User not found. Please check entered username or email. If you use email, perhaps the email is not verified.": [
-        ""
+        "ユーザーが見つかりませんでした。入力したユーザー名とメールアドレスを確認してください。もしくはメールアドレスが認証されていないようです。"
       ],
       "Default value of latitude for map\u00040": ["35.65810422222222"],
       "Default value of longitude for map\u00040": ["139.74135747222223"],

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -35,8 +35,8 @@
       "Are you sure you want to delete this Dataset?": [
         "本当にこのデータセットを削除しますか？"
       ],
-      "Please type in the name of the Dataset to confirm.": [
-        "確認のためにデータセット名を入力してください。"
+      "Please type delete to confirm.": [
+        "確認のために delete と入力してください。"
       ],
       "Error: Please upload GeoJSON file less than %d MB.": [
         "エラー: 5 MB 以下の GeoJSON ファイルをアップロードしてください。"
@@ -58,12 +58,8 @@
       "Anyone can access this GeoJSON API.": [
         "誰でもこの GeoJSON API にアクセスすることができます。"
       ],
-      "You can restrict the URLs that can use this GeoJSON API.": [
-        "この GeoJSON API を利用できる URL を制限することができます。"
-      ],
       "Datasets are published now.": ["データセットは公開されています。"],
       "Datasets status are draft now.": ["データセットは下書きの状態です。"],
-      "Upgrade to Geolonia Team": ["チーム機能をアップグレード"],
       "Name": ["名前"],
       "Name of public GeoJSON will be displayed in public.": [
         "公開されているGeoJSONの名前が表示されます。"
@@ -110,9 +106,6 @@
       "Are you sure you want to delete this dataset?": [
         "本当にこのデータセットを削除しますか？"
       ],
-      "Please type in the name of the dataset to confirm.": [
-        "確認のためにデータセット名を入力してください。"
-      ],
       "Public": ["一般公開"],
       "Public features will be displayed on <a class=\"MuiTypography-colorPrimary\" href=\"#\">open data directory</a> and anyone can download this features without API key.": [
         "一般公開のデータは、<a class=\"MuiTypography-colorPrimary\" href=\"#\">オープンデータディレクトリ</a>にて公開され、だれでも API キー無しでデータをダウンロードすることができます。"
@@ -146,9 +139,6 @@
       "Are you sure you want to delete this API key?": [
         "この API キーを本当に削除しますか？"
       ],
-      "Please type in the name of the API key to confirm.": [
-        "確認のために API キーの名前を入力してください。"
-      ],
       "Your API Key": ["あなたの API キー"],
       "Add the map to your site": ["ウェブサイトに地図を追加しましょう"],
       "Step 1": ["ステップ 1"],
@@ -180,7 +170,6 @@
       "Team Settings": ["チーム設定"],
       "General": ["一般"],
       "Members": ["メンバー"],
-      "Billing": ["支払い"],
       "Documentation": ["ドキュメント"],
       "Official Documents": ["公式ドキュメント"],
       "Dashboard": ["ダッシュボード"],
@@ -223,6 +212,11 @@
       "Sign in": ["サインイン"],
       "New to Geolonia?": ["アカウントをお持ちですか？"],
       "Create an account.": ["アカウントを作成"],
+      "Welcome to Geolonia": ["Geolonia へようこそ"],
+      "Create your account": ["アカウントを作成"],
+      "We are currently private beta. Sign Up is restricted to invited users.": [
+        "現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。"
+      ],
       "Username": ["ユーザー名"],
       "Username cannot be modified later.": [
         "ユーザー名は後から変更できません。"
@@ -231,11 +225,6 @@
       "Sign up": ["サインアップ"],
       "By signing up to Geolonia, you agree to our <a href=\"https://geolonia.com/terms\" class=\"MuiTypography-colorPrimary\">Terms of service</a> and <a class=\"MuiTypography-colorPrimary\" href=\"https://geolonia.com/privacy\">Privacy policy</a>.": [
         "サインアップすることで、私たちの <a href=\"https://geolonia.com/terms\" class=\"MuiTypography-colorPrimary\">利用規約</a> 及び <a class=\"MuiTypography-colorPrimary\" href=\"https://geolonia.com/privacy\">プライバシーポリシー</a> に同意したものとさせていただきます。"
-      ],
-      "Welcome to Geolonia": ["Geolonia へようこそ"],
-      "Create your account": ["アカウントを作成"],
-      "We are currently private beta. Sign Up is restricted to invited users.": [
-        "現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。"
       ],
       "Free plan": ["フリープラン"],
       "Team settings": ["チーム設定"],
@@ -390,7 +379,7 @@
         "ユーザー名には小文字（a-z）、数字（0-9）、ハイフン（-）、アンダースコア（-）、ピリオド（.）が利用でき、256文字以下である必要があります。"
       ],
       "Invalid parameter specified. You cannot use this username or email.": [
-        ""
+        "不正なパラメーターです。このユーザー名またはメールアドレスは利用できません。"
       ],
       "Invalid parameter specified. You cannot use this username, email, or verification code.": [
         "不正なパラメータです。このユーザー名、メールアドレスまたは認証コードは使用できません。"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -117,7 +117,7 @@ msgstr "最大アップロードファイルサイズ: %d MB"
 
 #: src/components/Data/GeoJsonImporter.tsx:112
 msgid "Existing feature that has same `id` will be updated."
-msgstr ""
+msgstr "同じ `id` を持つ地物が更新されます。"
 
 #: src/components/Data/GeoJsonImporter.tsx:96
 msgid "Error: The name of identifier `id` must be lower case."
@@ -591,29 +591,24 @@ msgstr "アカウントをお持ちですか？"
 msgid "Create an account."
 msgstr "アカウントを作成"
 
-#: src/components/Signup.tsx:100 src/components/verify.tsx:75
+#: src/components/Signup.tsx:104 src/components/verify.tsx:75
 msgid "Welcome to Geolonia"
 msgstr "Geolonia へようこそ"
 
-#: src/components/Signup.tsx:101
+#: src/components/Signup.tsx:105
 msgid "Create your account"
 msgstr "アカウントを作成"
 
-#: src/components/Signup.tsx:103
-msgid "We are currently private beta. Sign Up is restricted to invited users."
-msgstr ""
-"現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。"
-
-#: src/components/Signup.tsx:109 src/components/User/profile.tsx:109
+#: src/components/Signup.tsx:108 src/components/User/profile.tsx:109
 #: src/components/resend-code.tsx:56 src/components/verify.tsx:87
 msgid "Username"
 msgstr "ユーザー名"
 
-#: src/components/Signup.tsx:117
+#: src/components/Signup.tsx:116
 msgid "Username cannot be modified later."
 msgstr "ユーザー名は後から変更できません。"
 
-#: src/components/Signup.tsx:121
+#: src/components/Signup.tsx:120
 msgid "Email address"
 msgstr "Email アドレス"
 
@@ -638,7 +633,7 @@ msgid "Free plan"
 msgstr "フリープラン"
 
 #: src/components/Team/Billing.tsx:133 src/components/Team/general/index.tsx:31
-#: src/components/Team/members/index.tsx:126
+#: src/components/Team/members/index.tsx:127
 msgid "Team settings"
 msgstr "チーム設定"
 
@@ -728,7 +723,7 @@ msgstr ""
 "の左上にあるプルダウンで行うことができます。"
 
 #: src/components/Team/members/change-role.tsx:102
-#: src/components/Team/members/index.tsx:275
+#: src/components/Team/members/index.tsx:282
 msgid "Change role"
 msgstr "権限を変更"
 
@@ -746,7 +741,7 @@ msgid "Select a new role of %s."
 msgstr "%s の権限を選択して下さい。"
 
 #: src/components/Team/members/change-role.tsx:128
-#: src/components/Team/members/index.tsx:197
+#: src/components/Team/members/index.tsx:204
 msgid "Owner"
 msgstr "オーナー"
 
@@ -776,24 +771,28 @@ msgstr "APIキーを含むチームの全てのリソースを管理できます
 msgid "Save"
 msgstr "保存"
 
-#: src/components/Team/members/index.tsx:150
+#: src/components/Team/members/index.tsx:151
 msgid "You can manage members in your team."
 msgstr "チームメンバーの管理ができます。"
 
-#: src/components/Team/members/index.tsx:199
+#: src/components/Team/members/index.tsx:153
+msgid "We are in public beta version. Member features will be added soon."
+msgstr "現在パブリックβ版です。メンバー機能は近日追加されます。"
+
+#: src/components/Team/members/index.tsx:206
 msgid "Suspended"
 msgstr "一時停止"
 
-#: src/components/Team/members/index.tsx:237
+#: src/components/Team/members/index.tsx:244
 #: src/components/custom/AsyncTable.tsx:139 src/components/custom/Table.tsx:141
 msgid "rows per page"
 msgstr "表示する個数"
 
-#: src/components/Team/members/index.tsx:279
+#: src/components/Team/members/index.tsx:286
 msgid "Suspend"
 msgstr "一時停止"
 
-#: src/components/Team/members/index.tsx:283
+#: src/components/Team/members/index.tsx:290
 msgid "Remove from team"
 msgstr "チームから削除"
 
@@ -1148,6 +1147,8 @@ msgid ""
 "User not found. Please check entered username or email. If you use email, "
 "perhaps the email is not verified."
 msgstr ""
+"ユーザーが見つかりませんでした。入力したユーザー名とメールアドレスを確認して"
+"ください。もしくはメールアドレスが認証されていないようです。"
 
 #: src/components/Data/MapEditor.tsx:137
 msgctxt "Default value of latitude for map"
@@ -1163,6 +1164,12 @@ msgstr "139.74135747222223"
 msgctxt "Default value of zoom level of map"
 msgid "0"
 msgstr "6"
+
+#~ msgid ""
+#~ "We are currently private beta. Sign Up is restricted to invited users."
+#~ msgstr ""
+#~ "現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できま"
+#~ "す。"
 
 #~ msgid "Please type in the name of the Dataset to confirm."
 #~ msgstr "確認のためにデータセット名を入力してください。"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -33,7 +33,7 @@ msgstr "API キーを取得"
 msgid "Get API key then create your map!"
 msgstr "API キーを取得して新しい地図を作成しましょう。"
 
-#: src/components/Dashboard.tsx:73 src/components/Data/GeoJson.tsx:114
+#: src/components/Dashboard.tsx:73 src/components/Data/GeoJson.tsx:115
 #: src/components/Navigator.tsx:146
 msgid "GeoJSON API"
 msgstr ""
@@ -47,21 +47,21 @@ msgid "Developer's Blog"
 msgstr ""
 
 #: src/components/Data/ExportButton.tsx:32
-#: src/components/Data/GeoJsonMeta.tsx:268
+#: src/components/Data/GeoJsonMeta.tsx:278
 msgid "Download GeoJSON"
 msgstr "GeoJSON をダウンロード"
 
-#: src/components/Data/GeoJson.tsx:106 src/components/Data/GeoJsons.tsx:119
+#: src/components/Data/GeoJson.tsx:107 src/components/Data/GeoJsons.tsx:119
 #: src/components/Maps/APIKey.tsx:112 src/components/Maps/APIKeys.tsx:38
-#: src/components/Team/Billing.tsx:128
+#: src/components/Team/Billing.tsx:129
 msgid "Home"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:110 src/components/Data/GeoJsons.tsx:123
+#: src/components/Data/GeoJson.tsx:111 src/components/Data/GeoJsons.tsx:123
 msgid "API services"
 msgstr "API サービス"
 
-#: src/components/Data/GeoJson.tsx:328
+#: src/components/Data/GeoJson.tsx:333
 msgid ""
 "You can manage and style features in your GeoJSON, and get the the access "
 "point URL of GeoJSON API."
@@ -69,33 +69,34 @@ msgstr ""
 "GeoJSON 内の地物の管理をしたりスタイルを変更することができます。さらに、"
 "GeoJSON API のアクセスポイントの URL を取得できます。"
 
-#: src/components/Data/GeoJson.tsx:346
+#: src/components/Data/GeoJson.tsx:351
 msgid "Update required"
 msgstr "更新が必要です"
 
-#: src/components/Data/GeoJson.tsx:369
+#: src/components/Data/GeoJson.tsx:374
 msgid "Reload"
 msgstr "読み込み"
 
-#: src/components/Data/GeoJson.tsx:378
+#: src/components/Data/GeoJson.tsx:383
 msgid "Continue"
 msgstr "このまま続ける"
 
-#: src/components/Data/GeoJson.tsx:406
+#: src/components/Data/GeoJson.tsx:411
 msgid "Total Count of Features: %s"
 msgstr "%s 件のデータ"
 
-#: src/components/Data/GeoJson.tsx:428
+#: src/components/Data/GeoJson.tsx:433
 msgid "Once you delete an Dataset, there is no going back. Please be certain."
 msgstr "一度データセットを削除するともとに戻すことはできません。"
 
-#: src/components/Data/GeoJson.tsx:433
+#: src/components/Data/GeoJson.tsx:438
 msgid "Are you sure you want to delete this Dataset?"
 msgstr "本当にこのデータセットを削除しますか？"
 
-#: src/components/Data/GeoJson.tsx:434
-msgid "Please type in the name of the Dataset to confirm."
-msgstr "確認のためにデータセット名を入力してください。"
+#: src/components/Data/GeoJson.tsx:439 src/components/Data/fields.tsx:70
+#: src/components/Maps/APIKey.tsx:274
+msgid "Please type delete to confirm."
+msgstr "確認のために delete と入力してください。"
 
 #: src/components/Data/GeoJsonImporter.tsx:100
 msgid "Error: Please upload GeoJSON file less than %d MB."
@@ -128,27 +129,19 @@ msgstr ""
 "エラー: それぞれの `feature` の `id` は GeoJSON の中で一意である必要がありま"
 "す。"
 
-#: src/components/Data/GeoJsonMeta.tsx:211
+#: src/components/Data/GeoJsonMeta.tsx:220
 msgid "Anyone can access this GeoJSON API."
 msgstr "誰でもこの GeoJSON API にアクセスすることができます。"
 
-#: src/components/Data/GeoJsonMeta.tsx:214
-msgid "You can restrict the URLs that can use this GeoJSON API."
-msgstr "この GeoJSON API を利用できる URL を制限することができます。"
-
-#: src/components/Data/GeoJsonMeta.tsx:241
+#: src/components/Data/GeoJsonMeta.tsx:250
 msgid "Datasets are published now."
 msgstr "データセットは公開されています。"
 
-#: src/components/Data/GeoJsonMeta.tsx:243
+#: src/components/Data/GeoJsonMeta.tsx:252
 msgid "Datasets status are draft now."
 msgstr "データセットは下書きの状態です。"
 
-#: src/components/Data/GeoJsonMeta.tsx:246
-msgid "Upgrade to Geolonia Team"
-msgstr "チーム機能をアップグレード"
-
-#: src/components/Data/GeoJsonMeta.tsx:252 src/components/Data/fields.tsx:26
+#: src/components/Data/GeoJsonMeta.tsx:262 src/components/Data/fields.tsx:26
 #: src/components/Maps/APIKey.tsx:213 src/components/Navigator.tsx:317
 #: src/components/Team/general/fields.tsx:87
 #: src/components/User/profile.tsx:130 src/components/custom/AddNew.tsx:37
@@ -156,19 +149,19 @@ msgstr "チーム機能をアップグレード"
 msgid "Name"
 msgstr "名前"
 
-#: src/components/Data/GeoJsonMeta.tsx:263
+#: src/components/Data/GeoJsonMeta.tsx:273
 msgid "Name of public GeoJSON will be displayed in public."
 msgstr "公開されているGeoJSONの名前が表示されます。"
 
-#: src/components/Data/GeoJsonMeta.tsx:306
+#: src/components/Data/GeoJsonMeta.tsx:319
 msgid "Download"
 msgstr "GeoJSON をダウンロード"
 
-#: src/components/Data/GeoJsonMeta.tsx:311
+#: src/components/Data/GeoJsonMeta.tsx:324
 msgid "Or"
 msgstr "または"
 
-#: src/components/Data/GeoJsonMeta.tsx:314
+#: src/components/Data/GeoJsonMeta.tsx:327
 msgid "Copy endpoint URL to clipboard"
 msgstr "エンドポイント URL をクリップボードにコピー"
 
@@ -293,10 +286,6 @@ msgstr ""
 msgid "Are you sure you want to delete this dataset?"
 msgstr "本当にこのデータセットを削除しますか？"
 
-#: src/components/Data/fields.tsx:70
-msgid "Please type in the name of the dataset to confirm."
-msgstr "確認のためにデータセット名を入力してください。"
-
 #: src/components/Data/publish.tsx:34 src/components/custom/AsyncTable.tsx:119
 #: src/components/custom/Table.tsx:121
 msgid "Public"
@@ -397,10 +386,6 @@ msgstr ""
 msgid "Are you sure you want to delete this API key?"
 msgstr "この API キーを本当に削除しますか？"
 
-#: src/components/Maps/APIKey.tsx:274
-msgid "Please type in the name of the API key to confirm."
-msgstr "確認のために API キーの名前を入力してください。"
-
 #: src/components/Maps/APIKey.tsx:290
 msgid "Your API Key"
 msgstr "あなたの API キー"
@@ -490,10 +475,6 @@ msgstr "一般"
 msgid "Members"
 msgstr "メンバー"
 
-#: src/components/Navigator.tsx:170
-msgid "Billing"
-msgstr "支払い"
-
 #: src/components/Navigator.tsx:178
 msgid "Documentation"
 msgstr "ドキュメント"
@@ -534,7 +515,7 @@ msgstr "新しいパスワード"
 msgid "Confirm new password"
 msgstr "新しいパスワードを確認"
 
-#: src/components/ResetPassword.tsx:129 src/components/Signup.tsx:132
+#: src/components/ResetPassword.tsx:129 src/components/Signup.tsx:141
 msgid ""
 "Make sure at least 8 characters including a number and a lowercase letter."
 msgstr ""
@@ -590,7 +571,7 @@ msgstr "おっと、サーバーが正しく応答していないようです。
 msgid "Username or email address"
 msgstr "ユーザー名または Email アドレス"
 
-#: src/components/Signin.tsx:138 src/components/Signup.tsx:121
+#: src/components/Signin.tsx:138 src/components/Signup.tsx:130
 msgid "Password"
 msgstr "パスワード"
 
@@ -610,24 +591,37 @@ msgstr "アカウントをお持ちですか？"
 msgid "Create an account."
 msgstr "アカウントを作成"
 
-#: src/components/Signup.tsx:100 src/components/User/profile.tsx:109
+#: src/components/Signup.tsx:100 src/components/verify.tsx:75
+msgid "Welcome to Geolonia"
+msgstr "Geolonia へようこそ"
+
+#: src/components/Signup.tsx:101
+msgid "Create your account"
+msgstr "アカウントを作成"
+
+#: src/components/Signup.tsx:103
+msgid "We are currently private beta. Sign Up is restricted to invited users."
+msgstr ""
+"現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。"
+
+#: src/components/Signup.tsx:109 src/components/User/profile.tsx:109
 #: src/components/resend-code.tsx:56 src/components/verify.tsx:87
 msgid "Username"
 msgstr "ユーザー名"
 
-#: src/components/Signup.tsx:108
+#: src/components/Signup.tsx:117
 msgid "Username cannot be modified later."
 msgstr "ユーザー名は後から変更できません。"
 
-#: src/components/Signup.tsx:112
+#: src/components/Signup.tsx:121
 msgid "Email address"
 msgstr "Email アドレス"
 
-#: src/components/Signup.tsx:145
+#: src/components/Signup.tsx:154
 msgid "Sign up"
 msgstr "サインアップ"
 
-#: src/components/Signup.tsx:152
+#: src/components/Signup.tsx:161
 msgid ""
 "By signing up to Geolonia, you agree to our <a href=\"https://geolonia.com/"
 "terms\" class=\"MuiTypography-colorPrimary\">Terms of service</a> and <a "
@@ -639,57 +633,44 @@ msgstr ""
 "\"MuiTypography-colorPrimary\" href=\"https://geolonia.com/privacy\">プライバ"
 "シーポリシー</a> に同意したものとさせていただきます。"
 
-#: src/components/Signup.tsx:91 src/components/verify.tsx:75
-msgid "Welcome to Geolonia"
-msgstr "Geolonia へようこそ"
-
-#: src/components/Signup.tsx:92
-msgid "Create your account"
-msgstr "アカウントを作成"
-
-#: src/components/Signup.tsx:94
-msgid "We are currently private beta. Sign Up is restricted to invited users."
-msgstr ""
-"現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。"
-
-#: src/components/Team/Billing.tsx:106
+#: src/components/Team/Billing.tsx:107
 msgid "Free plan"
 msgstr "フリープラン"
 
-#: src/components/Team/Billing.tsx:132 src/components/Team/general/index.tsx:31
+#: src/components/Team/Billing.tsx:133 src/components/Team/general/index.tsx:31
 #: src/components/Team/members/index.tsx:126
 msgid "Team settings"
 msgstr "チーム設定"
 
-#: src/components/Team/Billing.tsx:141
+#: src/components/Team/Billing.tsx:142
 msgid "You can see subscriptions for this team in this month."
 msgstr "このチームの今月のサブスクリプションを確認することができます。"
 
-#: src/components/Team/Billing.tsx:147
+#: src/components/Team/Billing.tsx:148
 msgid "Payment information"
 msgstr "支払い情報"
 
-#: src/components/Team/Billing.tsx:153
+#: src/components/Team/Billing.tsx:154
 msgid "Payment method:"
 msgstr "支払い方法"
 
-#: src/components/Team/Billing.tsx:157
+#: src/components/Team/Billing.tsx:158
 msgid "ending in **%1$s"
 msgstr "末尾の番号 **%1$s"
 
-#: src/components/Team/Billing.tsx:167
+#: src/components/Team/Billing.tsx:168
 msgid "Change payment method"
 msgstr "支払い方法を変更"
 
-#: src/components/Team/Billing.tsx:177
+#: src/components/Team/Billing.tsx:178
 msgid "Current Plan"
 msgstr "現在のプラン"
 
-#: src/components/Team/Billing.tsx:188
+#: src/components/Team/Billing.tsx:189
 msgid "Change Plan"
 msgstr "プランを変更"
 
-#: src/components/Team/Billing.tsx:223
+#: src/components/Team/Billing.tsx:224
 msgid "Paid invoice receipts"
 msgstr ""
 
@@ -747,7 +728,7 @@ msgstr ""
 "の左上にあるプルダウンで行うことができます。"
 
 #: src/components/Team/members/change-role.tsx:102
-#: src/components/Team/members/index.tsx:274
+#: src/components/Team/members/index.tsx:275
 msgid "Change role"
 msgstr "権限を変更"
 
@@ -765,7 +746,7 @@ msgid "Select a new role of %s."
 msgstr "%s の権限を選択して下さい。"
 
 #: src/components/Team/members/change-role.tsx:128
-#: src/components/Team/members/index.tsx:196
+#: src/components/Team/members/index.tsx:197
 msgid "Owner"
 msgstr "オーナー"
 
@@ -795,24 +776,24 @@ msgstr "APIキーを含むチームの全てのリソースを管理できます
 msgid "Save"
 msgstr "保存"
 
-#: src/components/Team/members/index.tsx:149
+#: src/components/Team/members/index.tsx:150
 msgid "You can manage members in your team."
 msgstr "チームメンバーの管理ができます。"
 
-#: src/components/Team/members/index.tsx:198
+#: src/components/Team/members/index.tsx:199
 msgid "Suspended"
 msgstr "一時停止"
 
-#: src/components/Team/members/index.tsx:236
+#: src/components/Team/members/index.tsx:237
 #: src/components/custom/AsyncTable.tsx:139 src/components/custom/Table.tsx:141
 msgid "rows per page"
 msgstr "表示する個数"
 
-#: src/components/Team/members/index.tsx:278
+#: src/components/Team/members/index.tsx:279
 msgid "Suspend"
 msgstr "一時停止"
 
-#: src/components/Team/members/index.tsx:282
+#: src/components/Team/members/index.tsx:283
 msgid "Remove from team"
 msgstr "チームから削除"
 
@@ -1101,6 +1082,7 @@ msgstr ""
 #: src/lib/cognito/parse-error.ts:26
 msgid "Invalid parameter specified. You cannot use this username or email."
 msgstr ""
+"不正なパラメーターです。このユーザー名またはメールアドレスは利用できません。"
 
 #: src/lib/cognito/parse-error.ts:29
 msgid ""
@@ -1181,6 +1163,24 @@ msgstr "139.74135747222223"
 msgctxt "Default value of zoom level of map"
 msgid "0"
 msgstr "6"
+
+#~ msgid "Please type in the name of the Dataset to confirm."
+#~ msgstr "確認のためにデータセット名を入力してください。"
+
+#~ msgid "You can restrict the URLs that can use this GeoJSON API."
+#~ msgstr "この GeoJSON API を利用できる URL を制限することができます。"
+
+#~ msgid "Upgrade to Geolonia Team"
+#~ msgstr "チーム機能をアップグレード"
+
+#~ msgid "Please type in the name of the dataset to confirm."
+#~ msgstr "確認のためにデータセット名を入力してください。"
+
+#~ msgid "Please type in the name of the API key to confirm."
+#~ msgstr "確認のために API キーの名前を入力してください。"
+
+#~ msgid "Billing"
+#~ msgstr "支払い"
 
 #~ msgid "Private Endpoint"
 #~ msgstr "プライベートエンドポイント"

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -24,7 +24,7 @@ msgid "Get API key then create your map!"
 msgstr ""
 
 #: src/components/Dashboard.tsx:73
-#: src/components/Data/GeoJson.tsx:114
+#: src/components/Data/GeoJson.tsx:115
 #: src/components/Navigator.tsx:146
 msgid "GeoJSON API"
 msgstr ""
@@ -38,55 +38,57 @@ msgid "Developer's Blog"
 msgstr ""
 
 #: src/components/Data/ExportButton.tsx:32
-#: src/components/Data/GeoJsonMeta.tsx:268
+#: src/components/Data/GeoJsonMeta.tsx:278
 msgid "Download GeoJSON"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:106
+#: src/components/Data/GeoJson.tsx:107
 #: src/components/Data/GeoJsons.tsx:119
 #: src/components/Maps/APIKey.tsx:112
 #: src/components/Maps/APIKeys.tsx:38
-#: src/components/Team/Billing.tsx:128
+#: src/components/Team/Billing.tsx:129
 msgid "Home"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:110
+#: src/components/Data/GeoJson.tsx:111
 #: src/components/Data/GeoJsons.tsx:123
 msgid "API services"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:328
+#: src/components/Data/GeoJson.tsx:333
 msgid ""
 "You can manage and style features in your GeoJSON, and get the the access "
 "point URL of GeoJSON API."
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:346
+#: src/components/Data/GeoJson.tsx:351
 msgid "Update required"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:369
+#: src/components/Data/GeoJson.tsx:374
 msgid "Reload"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:378
+#: src/components/Data/GeoJson.tsx:383
 msgid "Continue"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:406
+#: src/components/Data/GeoJson.tsx:411
 msgid "Total Count of Features: %s"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:428
+#: src/components/Data/GeoJson.tsx:433
 msgid "Once you delete an Dataset, there is no going back. Please be certain."
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:433
+#: src/components/Data/GeoJson.tsx:438
 msgid "Are you sure you want to delete this Dataset?"
 msgstr ""
 
-#: src/components/Data/GeoJson.tsx:434
-msgid "Please type in the name of the Dataset to confirm."
+#: src/components/Data/GeoJson.tsx:439
+#: src/components/Data/fields.tsx:70
+#: src/components/Maps/APIKey.tsx:274
+msgid "Please type delete to confirm."
 msgstr ""
 
 #: src/components/Data/GeoJsonImporter.tsx:100
@@ -118,27 +120,19 @@ msgstr ""
 msgid "Error: The `id` of each `fueature` must be unique in the GeoJSON."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:211
+#: src/components/Data/GeoJsonMeta.tsx:220
 msgid "Anyone can access this GeoJSON API."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:214
-msgid "You can restrict the URLs that can use this GeoJSON API."
-msgstr ""
-
-#: src/components/Data/GeoJsonMeta.tsx:241
+#: src/components/Data/GeoJsonMeta.tsx:250
 msgid "Datasets are published now."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:243
+#: src/components/Data/GeoJsonMeta.tsx:252
 msgid "Datasets status are draft now."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:246
-msgid "Upgrade to Geolonia Team"
-msgstr ""
-
-#: src/components/Data/GeoJsonMeta.tsx:252
+#: src/components/Data/GeoJsonMeta.tsx:262
 #: src/components/Data/fields.tsx:26
 #: src/components/Maps/APIKey.tsx:213
 #: src/components/Navigator.tsx:317
@@ -149,19 +143,19 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:263
+#: src/components/Data/GeoJsonMeta.tsx:273
 msgid "Name of public GeoJSON will be displayed in public."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:306
+#: src/components/Data/GeoJsonMeta.tsx:319
 msgid "Download"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:311
+#: src/components/Data/GeoJsonMeta.tsx:324
 msgid "Or"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:314
+#: src/components/Data/GeoJsonMeta.tsx:327
 msgid "Copy endpoint URL to clipboard"
 msgstr ""
 
@@ -285,10 +279,6 @@ msgstr ""
 msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
-#: src/components/Data/fields.tsx:70
-msgid "Please type in the name of the dataset to confirm."
-msgstr ""
-
 #: src/components/Data/publish.tsx:34
 #: src/components/custom/AsyncTable.tsx:119
 #: src/components/custom/Table.tsx:121
@@ -385,10 +375,6 @@ msgstr ""
 msgid "Are you sure you want to delete this API key?"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:274
-msgid "Please type in the name of the API key to confirm."
-msgstr ""
-
 #: src/components/Maps/APIKey.tsx:290
 msgid "Your API Key"
 msgstr ""
@@ -476,10 +462,6 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-#: src/components/Navigator.tsx:170
-msgid "Billing"
-msgstr ""
-
 #: src/components/Navigator.tsx:178
 msgid "Documentation"
 msgstr ""
@@ -525,7 +507,7 @@ msgid "Confirm new password"
 msgstr ""
 
 #: src/components/ResetPassword.tsx:129
-#: src/components/Signup.tsx:132
+#: src/components/Signup.tsx:141
 msgid "Make sure at least 8 characters including a number and a lowercase letter."
 msgstr ""
 
@@ -578,7 +560,7 @@ msgid "Username or email address"
 msgstr ""
 
 #: src/components/Signin.tsx:138
-#: src/components/Signup.tsx:121
+#: src/components/Signup.tsx:130
 msgid "Password"
 msgstr ""
 
@@ -599,25 +581,38 @@ msgid "Create an account."
 msgstr ""
 
 #: src/components/Signup.tsx:100
+#: src/components/verify.tsx:75
+msgid "Welcome to Geolonia"
+msgstr ""
+
+#: src/components/Signup.tsx:101
+msgid "Create your account"
+msgstr ""
+
+#: src/components/Signup.tsx:103
+msgid "We are currently private beta. Sign Up is restricted to invited users."
+msgstr ""
+
+#: src/components/Signup.tsx:109
 #: src/components/User/profile.tsx:109
 #: src/components/resend-code.tsx:56
 #: src/components/verify.tsx:87
 msgid "Username"
 msgstr ""
 
-#: src/components/Signup.tsx:108
+#: src/components/Signup.tsx:117
 msgid "Username cannot be modified later."
 msgstr ""
 
-#: src/components/Signup.tsx:112
+#: src/components/Signup.tsx:121
 msgid "Email address"
 msgstr ""
 
-#: src/components/Signup.tsx:145
+#: src/components/Signup.tsx:154
 msgid "Sign up"
 msgstr ""
 
-#: src/components/Signup.tsx:152
+#: src/components/Signup.tsx:161
 msgid ""
 "By signing up to Geolonia, you agree to our <a "
 "href=\"https://geolonia.com/terms\" "
@@ -626,58 +621,45 @@ msgid ""
 "href=\"https://geolonia.com/privacy\">Privacy policy</a>."
 msgstr ""
 
-#: src/components/Signup.tsx:91
-#: src/components/verify.tsx:75
-msgid "Welcome to Geolonia"
-msgstr ""
-
-#: src/components/Signup.tsx:92
-msgid "Create your account"
-msgstr ""
-
-#: src/components/Signup.tsx:94
-msgid "We are currently private beta. Sign Up is restricted to invited users."
-msgstr ""
-
-#: src/components/Team/Billing.tsx:106
+#: src/components/Team/Billing.tsx:107
 msgid "Free plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:132
+#: src/components/Team/Billing.tsx:133
 #: src/components/Team/general/index.tsx:31
 #: src/components/Team/members/index.tsx:126
 msgid "Team settings"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:141
+#: src/components/Team/Billing.tsx:142
 msgid "You can see subscriptions for this team in this month."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:147
+#: src/components/Team/Billing.tsx:148
 msgid "Payment information"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:153
+#: src/components/Team/Billing.tsx:154
 msgid "Payment method:"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:157
+#: src/components/Team/Billing.tsx:158
 msgid "ending in **%1$s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:167
+#: src/components/Team/Billing.tsx:168
 msgid "Change payment method"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:177
+#: src/components/Team/Billing.tsx:178
 msgid "Current Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:188
+#: src/components/Team/Billing.tsx:189
 msgid "Change Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:223
+#: src/components/Team/Billing.tsx:224
 msgid "Paid invoice receipts"
 msgstr ""
 
@@ -732,7 +714,7 @@ msgid ""
 msgstr ""
 
 #: src/components/Team/members/change-role.tsx:102
-#: src/components/Team/members/index.tsx:274
+#: src/components/Team/members/index.tsx:275
 msgid "Change role"
 msgstr ""
 
@@ -747,7 +729,7 @@ msgid "Select a new role of %s."
 msgstr ""
 
 #: src/components/Team/members/change-role.tsx:128
-#: src/components/Team/members/index.tsx:196
+#: src/components/Team/members/index.tsx:197
 msgid "Owner"
 msgstr ""
 
@@ -778,25 +760,25 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:149
+#: src/components/Team/members/index.tsx:150
 msgid "You can manage members in your team."
 msgstr ""
 
-#: src/components/Team/members/index.tsx:198
+#: src/components/Team/members/index.tsx:199
 msgid "Suspended"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:236
+#: src/components/Team/members/index.tsx:237
 #: src/components/custom/AsyncTable.tsx:139
 #: src/components/custom/Table.tsx:141
 msgid "rows per page"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:278
+#: src/components/Team/members/index.tsx:279
 msgid "Suspend"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:282
+#: src/components/Team/members/index.tsx:283
 msgid "Remove from team"
 msgstr ""
 

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -580,31 +580,27 @@ msgstr ""
 msgid "Create an account."
 msgstr ""
 
-#: src/components/Signup.tsx:100
+#: src/components/Signup.tsx:104
 #: src/components/verify.tsx:75
 msgid "Welcome to Geolonia"
 msgstr ""
 
-#: src/components/Signup.tsx:101
+#: src/components/Signup.tsx:105
 msgid "Create your account"
 msgstr ""
 
-#: src/components/Signup.tsx:103
-msgid "We are currently private beta. Sign Up is restricted to invited users."
-msgstr ""
-
-#: src/components/Signup.tsx:109
+#: src/components/Signup.tsx:108
 #: src/components/User/profile.tsx:109
 #: src/components/resend-code.tsx:56
 #: src/components/verify.tsx:87
 msgid "Username"
 msgstr ""
 
-#: src/components/Signup.tsx:117
+#: src/components/Signup.tsx:116
 msgid "Username cannot be modified later."
 msgstr ""
 
-#: src/components/Signup.tsx:121
+#: src/components/Signup.tsx:120
 msgid "Email address"
 msgstr ""
 
@@ -627,7 +623,7 @@ msgstr ""
 
 #: src/components/Team/Billing.tsx:133
 #: src/components/Team/general/index.tsx:31
-#: src/components/Team/members/index.tsx:126
+#: src/components/Team/members/index.tsx:127
 msgid "Team settings"
 msgstr ""
 
@@ -714,7 +710,7 @@ msgid ""
 msgstr ""
 
 #: src/components/Team/members/change-role.tsx:102
-#: src/components/Team/members/index.tsx:275
+#: src/components/Team/members/index.tsx:282
 msgid "Change role"
 msgstr ""
 
@@ -729,7 +725,7 @@ msgid "Select a new role of %s."
 msgstr ""
 
 #: src/components/Team/members/change-role.tsx:128
-#: src/components/Team/members/index.tsx:197
+#: src/components/Team/members/index.tsx:204
 msgid "Owner"
 msgstr ""
 
@@ -760,25 +756,29 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:150
+#: src/components/Team/members/index.tsx:151
 msgid "You can manage members in your team."
 msgstr ""
 
-#: src/components/Team/members/index.tsx:199
+#: src/components/Team/members/index.tsx:153
+msgid "We are in public beta version. Member features will be added soon."
+msgstr ""
+
+#: src/components/Team/members/index.tsx:206
 msgid "Suspended"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:237
+#: src/components/Team/members/index.tsx:244
 #: src/components/custom/AsyncTable.tsx:139
 #: src/components/custom/Table.tsx:141
 msgid "rows per page"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:279
+#: src/components/Team/members/index.tsx:286
 msgid "Suspend"
 msgstr ""
 
-#: src/components/Team/members/index.tsx:283
+#: src/components/Team/members/index.tsx:290
 msgid "Remove from team"
 msgstr ""
 


### PR DESCRIPTION
以下の修正を追加しました。

- サインアップ画面の「現在はプライベートβ版です。招待されたユーザーのみがアカウントを作成できます。」 を削除
- サインアップの際メールアドレスのスペースはトリムする (サーバー側でもバリデーションされます)
- `/#/geojson/unknown` のように存在しない GeoJSON ID のページにアクセスしようとするとクラッシュするのを修正
- メンバー招待ページに現在β版であることを記載
<img width="1552" alt="Screen Shot 2020-06-22 at 19 47 50" src="https://user-images.githubusercontent.com/6292312/85279368-48208500-b4c1-11ea-919b-30e123b5eb5d.png">
<img width="1552" alt="Screen Shot 2020-06-22 at 19 43 32" src="https://user-images.githubusercontent.com/6292312/85279377-4a82df00-b4c1-11ea-8996-d59140bc6ffd.png">

