### PR TITLE
Add bundle mode for monaca

### DIFF
--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -129,11 +129,17 @@
       "Configure access control for your API key and Get the HTML code for your map.": [
         "API キーのアクセスコントロールを設定して、地図を設置するための HTML コードを取得しましょう。"
       ],
+      "Mode": ["モード"],
+      "Publishable Mode": ["公開可能モード"],
+      "Bundle Mode": ["バンドルモード"],
       "Any page in a specific URL:": ["指定された URL 以下のすべてのページ:"],
       "Any subdomain:": ["すべてのサブドメイン:"],
       "A URL with a non-standard port:": ["一般的ではないポート:"],
       "Note: Wild card (*) will be matched to a-z, A-Z, 0-9, \"-\", \"_\".": [
         "備考: ワイルドカード (*) は、a-z, A-Z, 0-9, \"-\", \"_\" のいずれかと一致します。"
+      ],
+      "The any match (*) is only allowed in bundle mode.": [
+        "任意の一致(*)はバンドルモードでのみ許可されます。"
       ],
       "Once you delete an API, there is no going back. Please be certain.": [
         "API キーを一度削除したらもとに戻すことはできません。よく確認して実行してください。"
@@ -274,7 +280,7 @@
         "チームメンバーの管理ができます。"
       ],
       "We are in public beta version. Member features will be added soon.": [
-        ""
+        "現在は公開β版です。メンバー機能は後ほど追加されます。"
       ],
       "Suspended": ["一時停止"],
       "rows per page": ["表示する個数"],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -52,7 +52,7 @@ msgid "Download GeoJSON"
 msgstr "GeoJSON をダウンロード"
 
 #: src/components/Data/GeoJson.tsx:104 src/components/Data/GeoJsons.tsx:119
-#: src/components/Maps/APIKey.tsx:113 src/components/Maps/APIKeys.tsx:35
+#: src/components/Maps/APIKey.tsx:151 src/components/Maps/APIKeys.tsx:35
 #: src/components/Team/Billing.tsx:128
 msgid "Home"
 msgstr ""
@@ -94,7 +94,7 @@ msgid "Are you sure you want to delete this Dataset?"
 msgstr "本当にこのデータセットを削除しますか？"
 
 #: src/components/Data/GeoJson.tsx:436 src/components/Data/fields.tsx:70
-#: src/components/Maps/APIKey.tsx:275
+#: src/components/Maps/APIKey.tsx:324
 msgid "Please type delete to confirm."
 msgstr "確認のために delete と入力してください。"
 
@@ -146,7 +146,7 @@ msgid "Datasets status are draft now."
 msgstr "データセットは下書きの状態です。"
 
 #: src/components/Data/GeoJsonMeta.tsx:265 src/components/Data/fields.tsx:26
-#: src/components/Maps/APIKey.tsx:214 src/components/Navigator.tsx:313
+#: src/components/Maps/APIKey.tsx:236 src/components/Navigator.tsx:313
 #: src/components/Team/general/fields.tsx:84
 #: src/components/User/profile.tsx:129 src/components/custom/AddNew.tsx:37
 #: src/components/custom/Delete.tsx:121
@@ -263,11 +263,11 @@ msgstr "文字色"
 msgid "Text Halo Color"
 msgstr "文字の輪郭色"
 
-#: src/components/Data/fields.tsx:40 src/components/Maps/APIKey.tsx:225
+#: src/components/Data/fields.tsx:40 src/components/Maps/APIKey.tsx:270
 msgid "URLs"
 msgstr "URL のリスト"
 
-#: src/components/Data/fields.tsx:50 src/components/Maps/APIKey.tsx:238
+#: src/components/Data/fields.tsx:50 src/components/Maps/APIKey.tsx:283
 msgid ""
 "URLs will be used for an HTTP referrer to restrict the URLs that can use an "
 "API key."
@@ -346,92 +346,108 @@ msgstr "プロフィール"
 msgid "Logout"
 msgstr "ログアウト"
 
-#: src/components/Maps/APIKey.tsx:117 src/components/Maps/APIKeys.tsx:69
+#: src/components/Maps/APIKey.tsx:155 src/components/Maps/APIKeys.tsx:69
 #: src/components/Navigator.tsx:127
 msgid "API keys"
 msgstr "API キー"
 
-#: src/components/Maps/APIKey.tsx:204
+#: src/components/Maps/APIKey.tsx:226
 msgid "API key settings"
 msgstr "API キーの設定"
 
-#: src/components/Maps/APIKey.tsx:205
+#: src/components/Maps/APIKey.tsx:227
 msgid ""
 "Configure access control for your API key and Get the HTML code for your map."
 msgstr ""
 "API キーのアクセスコントロールを設定して、地図を設置するための HTML コードを"
 "取得しましょう。"
 
-#: src/components/Maps/APIKey.tsx:244
+#: src/components/Maps/APIKey.tsx:248
+msgid "Mode"
+msgstr "モード"
+
+#: src/components/Maps/APIKey.tsx:257
+msgid "Publishable Mode"
+msgstr "公開可能モード"
+
+#: src/components/Maps/APIKey.tsx:262
+msgid "Bundle Mode"
+msgstr "バンドルモード"
+
+#: src/components/Maps/APIKey.tsx:289
 msgid "Any page in a specific URL:"
 msgstr "指定された URL 以下のすべてのページ:"
 
-#: src/components/Maps/APIKey.tsx:248
+#: src/components/Maps/APIKey.tsx:293
 msgid "Any subdomain:"
 msgstr "すべてのサブドメイン:"
 
-#: src/components/Maps/APIKey.tsx:251
+#: src/components/Maps/APIKey.tsx:296
 msgid "A URL with a non-standard port:"
 msgstr "一般的ではないポート:"
 
-#: src/components/Maps/APIKey.tsx:256
+#: src/components/Maps/APIKey.tsx:301
 msgid "Note: Wild card (*) will be matched to a-z, A-Z, 0-9, \"-\", \"_\"."
 msgstr ""
 "備考: ワイルドカード (*) は、a-z, A-Z, 0-9, \"-\", \"_\" のいずれかと一致しま"
 "す。"
 
-#: src/components/Maps/APIKey.tsx:269
+#: src/components/Maps/APIKey.tsx:308
+msgid "The any match (*) is only allowed in bundle mode."
+msgstr "任意の一致(*)はバンドルモードでのみ許可されます。"
+
+#: src/components/Maps/APIKey.tsx:318
 msgid "Once you delete an API, there is no going back. Please be certain."
 msgstr ""
 "API キーを一度削除したらもとに戻すことはできません。よく確認して実行してくだ"
 "さい。"
 
-#: src/components/Maps/APIKey.tsx:274
+#: src/components/Maps/APIKey.tsx:323
 msgid "Are you sure you want to delete this API key?"
 msgstr "この API キーを本当に削除しますか？"
 
-#: src/components/Maps/APIKey.tsx:291
+#: src/components/Maps/APIKey.tsx:340
 msgid "Your API Key"
 msgstr "あなたの API キー"
 
-#: src/components/Maps/APIKey.tsx:297
+#: src/components/Maps/APIKey.tsx:346
 msgid "Add the map to your site"
 msgstr "ウェブサイトに地図を追加しましょう"
 
-#: src/components/Maps/APIKey.tsx:300
+#: src/components/Maps/APIKey.tsx:349
 msgid "Step 1"
 msgstr "ステップ 1"
 
-#: src/components/Maps/APIKey.tsx:304
+#: src/components/Maps/APIKey.tsx:353
 msgid ""
 "Include the following code before closing tag of the <code>&lt;body /&gt;</"
 "code> in your HTML file."
 msgstr ""
 "<code>&lt;body /&gt;</code> の終了タグ直前に以下のコードを挿入してください。"
 
-#: src/components/Maps/APIKey.tsx:327
+#: src/components/Maps/APIKey.tsx:376
 msgid "Step 2"
 msgstr "ステップ 2"
 
-#: src/components/Maps/APIKey.tsx:330
+#: src/components/Maps/APIKey.tsx:379
 msgid ""
 "Click following button and get HTML code where you want to place the map."
 msgstr ""
 "以下のボタンをクリックして地図を表示したい場所の HTML を取得してください。"
 
-#: src/components/Maps/APIKey.tsx:342
+#: src/components/Maps/APIKey.tsx:391
 msgid "Get HTML"
 msgstr "HTML を取得"
 
-#: src/components/Maps/APIKey.tsx:346
+#: src/components/Maps/APIKey.tsx:395
 msgid "Step 3"
 msgstr "ステップ 3"
 
-#: src/components/Maps/APIKey.tsx:348
+#: src/components/Maps/APIKey.tsx:397
 msgid "Adjust the element size."
 msgstr "地図を表示する要素のサイズを調整して下さい。"
 
-#: src/components/Maps/APIKey.tsx:363
+#: src/components/Maps/APIKey.tsx:412
 msgid "Copy to Clipboard"
 msgstr "クリップボードにコピー"
 

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -44,7 +44,7 @@ msgstr ""
 
 #: src/components/Data/GeoJson.tsx:104
 #: src/components/Data/GeoJsons.tsx:119
-#: src/components/Maps/APIKey.tsx:113
+#: src/components/Maps/APIKey.tsx:151
 #: src/components/Maps/APIKeys.tsx:35
 #: src/components/Team/Billing.tsx:128
 msgid "Home"
@@ -87,7 +87,7 @@ msgstr ""
 
 #: src/components/Data/GeoJson.tsx:436
 #: src/components/Data/fields.tsx:70
-#: src/components/Maps/APIKey.tsx:275
+#: src/components/Maps/APIKey.tsx:324
 msgid "Please type delete to confirm."
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 
 #: src/components/Data/GeoJsonMeta.tsx:265
 #: src/components/Data/fields.tsx:26
-#: src/components/Maps/APIKey.tsx:214
+#: src/components/Maps/APIKey.tsx:236
 #: src/components/Navigator.tsx:313
 #: src/components/Team/general/fields.tsx:84
 #: src/components/User/profile.tsx:129
@@ -256,12 +256,12 @@ msgid "Text Halo Color"
 msgstr ""
 
 #: src/components/Data/fields.tsx:40
-#: src/components/Maps/APIKey.tsx:225
+#: src/components/Maps/APIKey.tsx:270
 msgid "URLs"
 msgstr ""
 
 #: src/components/Data/fields.tsx:50
-#: src/components/Maps/APIKey.tsx:238
+#: src/components/Maps/APIKey.tsx:283
 msgid ""
 "URLs will be used for an HTTP referrer to restrict the URLs that can use an "
 "API key."
@@ -337,85 +337,101 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:117
+#: src/components/Maps/APIKey.tsx:155
 #: src/components/Maps/APIKeys.tsx:69
 #: src/components/Navigator.tsx:127
 msgid "API keys"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:204
+#: src/components/Maps/APIKey.tsx:226
 msgid "API key settings"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:205
+#: src/components/Maps/APIKey.tsx:227
 msgid ""
 "Configure access control for your API key and Get the HTML code for your "
 "map."
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:244
+#: src/components/Maps/APIKey.tsx:248
+msgid "Mode"
+msgstr ""
+
+#: src/components/Maps/APIKey.tsx:257
+msgid "Publishable Mode"
+msgstr ""
+
+#: src/components/Maps/APIKey.tsx:262
+msgid "Bundle Mode"
+msgstr ""
+
+#: src/components/Maps/APIKey.tsx:289
 msgid "Any page in a specific URL:"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:248
+#: src/components/Maps/APIKey.tsx:293
 msgid "Any subdomain:"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:251
+#: src/components/Maps/APIKey.tsx:296
 msgid "A URL with a non-standard port:"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:256
+#: src/components/Maps/APIKey.tsx:301
 msgid "Note: Wild card (*) will be matched to a-z, A-Z, 0-9, \"-\", \"_\"."
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:269
+#: src/components/Maps/APIKey.tsx:308
+msgid "The any match (*) is only allowed in bundle mode."
+msgstr ""
+
+#: src/components/Maps/APIKey.tsx:318
 msgid "Once you delete an API, there is no going back. Please be certain."
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:274
+#: src/components/Maps/APIKey.tsx:323
 msgid "Are you sure you want to delete this API key?"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:291
+#: src/components/Maps/APIKey.tsx:340
 msgid "Your API Key"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:297
+#: src/components/Maps/APIKey.tsx:346
 msgid "Add the map to your site"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:300
+#: src/components/Maps/APIKey.tsx:349
 msgid "Step 1"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:304
+#: src/components/Maps/APIKey.tsx:353
 msgid ""
 "Include the following code before closing tag of the <code>&lt;body "
 "/&gt;</code> in your HTML file."
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:327
+#: src/components/Maps/APIKey.tsx:376
 msgid "Step 2"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:330
+#: src/components/Maps/APIKey.tsx:379
 msgid "Click following button and get HTML code where you want to place the map."
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:342
+#: src/components/Maps/APIKey.tsx:391
 msgid "Get HTML"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:346
+#: src/components/Maps/APIKey.tsx:395
 msgid "Step 3"
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:348
+#: src/components/Maps/APIKey.tsx:397
 msgid "Adjust the element size."
 msgstr ""
 
-#: src/components/Maps/APIKey.tsx:363
+#: src/components/Maps/APIKey.tsx:412
 msgid "Copy to Clipboard"
 msgstr ""
 


### PR DESCRIPTION
Monaca/Cordova 用のバンドルモードというのを作りました。
挙動は URL リストに * を追加しているだけなのですが、ユーザーさんにラジオボタンで選ぶというステップを踏んでもらうようにしています。
公開可能モード（デフォルト）の場合は * を入力できないようになっています。

<img width="942" alt="Screen Shot 2020-07-07 at 12 52 27" src="https://user-images.githubusercontent.com/6292312/86705384-c8fa8780-c050-11ea-9620-92105f12fe48.png">
