### PR TITLE
Add origin auth form

### DIFF
--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -414,6 +414,7 @@ const Content = (props: Props) => {
             geojsonId={props.geojsonId}
             name={geoJsonMeta.name}
             isPublic={geoJsonMeta.isPublic}
+            allowedOrigins={geoJsonMeta.allowedOrigins}
             status={geoJsonMeta.status}
             setGeoJsonMeta={setGeoJsonMeta}
             style={style}

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -43,7 +43,8 @@ export default function useGeoJSON(
           }
         })
         .then(json => {
-          const allowedOrigins = typeof json.allowedOrigins !== "undefined" ? json.allowedOrigins : "";
+          const allowedOrigins = 
+            typeof json.allowedOrigins !== "undefined" ? json.allowedOrigins : "";
           setGeoJsonMeta({ ...json, allowedOrigins });
         })
         .catch(() => setError(true));

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -9,7 +9,7 @@ const { REACT_APP_STAGE } = process.env;
 type GeoJSONMeta = {
   name: string;
   isPublic: boolean;
-  allowedOrigins: string;
+  allowedOrigins: Array<string> | string;
   status: string;
 };
 
@@ -43,7 +43,7 @@ export default function useGeoJSON(
           }
         })
         .then(json => {
-          const allowedOrigins = typeof json.allowedOrigins !== "undefined" ? json.allowedOrigins : [];
+          const allowedOrigins = typeof json.allowedOrigins !== "undefined" ? json.allowedOrigins : "";
           setGeoJsonMeta({ ...json, allowedOrigins });
         })
         .catch(() => setError(true));

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -9,7 +9,7 @@ const { REACT_APP_STAGE } = process.env;
 type GeoJSONMeta = {
   name: string;
   isPublic: boolean;
-  allowedOrigins: Array<string> | string;
+  allowedOrigins: string[];
   status: string;
 };
 
@@ -44,7 +44,7 @@ export default function useGeoJSON(
         })
         .then(json => {
           const allowedOrigins = 
-            typeof json.allowedOrigins !== "undefined" ? json.allowedOrigins : "";
+            typeof json.allowedOrigins !== "undefined" ? json.allowedOrigins : [];
           setGeoJsonMeta({ ...json, allowedOrigins });
         })
         .catch(() => setError(true));

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -43,8 +43,7 @@ export default function useGeoJSON(
           }
         })
         .then(json => {
-          const allowedOrigins =
-            typeof json.allowedOrigins === "string" ? json.allowedOrigins : "";
+          const allowedOrigins = typeof json.allowedOrigins !== "undefined" ? json.allowedOrigins : [];
           setGeoJsonMeta({ ...json, allowedOrigins });
         })
         .catch(() => setError(true));

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -9,6 +9,7 @@ const { REACT_APP_STAGE } = process.env;
 type GeoJSONMeta = {
   name: string;
   isPublic: boolean;
+  allowedOrigins: string;
   status: string;
 };
 

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -167,6 +167,15 @@ const GeoJSONMeta = (props: Props) => {
   const [saveStatus, setSaveStatus] = React.useState<false | "requesting" | "success" | "failure">(false);
   const onRequestError = () => setSaveStatus("failure");
   const propOrigins = (props || { allowedOrigins: [] }).allowedOrigins;
+
+  // effects
+  React.useEffect(() => {
+    if (typeof propOrigins === "string") {
+      setAllowedOrigins(propOrigins);
+    } else {
+      setAllowedOrigins(propOrigins.join("\n"));
+    }
+  }, [propOrigins]);
   
   // fire save name request
   const saveHandler = (draftName: string) => {
@@ -197,12 +206,7 @@ const GeoJSONMeta = (props: Props) => {
       });
   };
 
-  let saveDisabled = false
-  if (typeof propOrigins === "string") {
-    saveDisabled = allowedOrigins === propOrigins
-  } else {
-    saveDisabled = allowedOrigins === propOrigins.join("\n")
-  }
+  const saveDisabled = allowedOrigins === ((typeof propOrigins === "string") ? propOrigins: propOrigins.join("\n"))
 
   const onUpdateClick = () => {
     if (saveDisabled || !session) {
@@ -216,7 +220,6 @@ const GeoJSONMeta = (props: Props) => {
       .filter(url => !!url)
       .map(origin => normalizeOrigin(origin));
 
-    console.log(normalizedAllowedOrigins)
     return fetch(
       session,
       `https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/${geojsonId}`,

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -258,7 +258,7 @@ const GeoJSONMeta = (props: Props) => {
               }}
               // NOTE: Billing feature
               // disabled={!props.isPaidTeam}
-              disabled={true}
+              disabled={false}
               inputProps={{ "aria-label": "primary checkbox" }}
               color="primary"
             />

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -21,6 +21,12 @@ import { buildApiUrl } from "../../lib/api";
 
 const { REACT_APP_STAGE } = process.env;
 
+type Meta = {
+  name: string;
+  isPublic: boolean;
+  status: string;
+};
+
 type OwnProps = {
   geojsonId: string;
   name: string;
@@ -235,7 +241,7 @@ const GeoJSONMeta = (props: Props) => {
         setSaveStatus("success");
         setGeoJsonMeta({ isPublic, name, allowedOrigins: normalizedAllowedOrigins, status });
       });
-  }, [draftAllowedOrigins, geojsonId, isPublic, name, saveDisabled, session, setGeoJsonMeta, status])
+  }, [draftAllowedOrigins, geojsonId, isPublic, name, saveDisabled, session, status])
 
   const downloadDisabled = status === "draft" || !isPublic;
   const downloadUrl = buildApiUrl(`/geojsons/pub/${geojsonId}`);

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -241,7 +241,7 @@ const GeoJSONMeta = (props: Props) => {
         setSaveStatus("success");
         setGeoJsonMeta({ isPublic, name, allowedOrigins: normalizedAllowedOrigins, status });
       });
-  }, [draftAllowedOrigins, geojsonId, isPublic, name, saveDisabled, session, status])
+  }, [draftAllowedOrigins, geojsonId, isPublic, name, saveDisabled, session, status, setGeoJsonMeta])
 
   const downloadDisabled = status === "draft" || !isPublic;
   const downloadUrl = buildApiUrl(`/geojsons/pub/${geojsonId}`);

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -259,7 +259,6 @@ const GeoJSONMeta = (props: Props) => {
               }}
               // NOTE: Billing feature
               // disabled={!props.isPaidTeam}
-              disabled={false}
               inputProps={{ "aria-label": "primary checkbox" }}
               color="primary"
             />

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -332,6 +332,9 @@ const GeoJSONMeta = (props: Props) => {
             </p>
           )}
         </Paper>
+        {(isPublic || draftIsPublic) && (
+          <Paper className="geojson-title-description">Helllo</Paper>
+        )}
       </Grid>
     </Grid>
   );

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -33,14 +33,17 @@ type OwnProps = {
   geojsonId: string;
   name: string;
   isPublic: boolean;
+  allowedOrigins: string;
   status: string;
   setGeoJsonMeta: ({
     name,
     isPublic,
+    allowedOrigins,
     status
   }: {
     name: string;
     isPublic: boolean;
+    allowedOrigins: string;
     status: string;
   }) => void;
 

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -13,12 +13,9 @@ import { __ } from "@wordpress/i18n";
 import { connect } from "react-redux";
 import Save from "../custom/Save";
 import fetch from "../../lib/fetch";
-
 import Typography from "@material-ui/core/Typography";
 import TextField from "@material-ui/core/TextField";
 import Help from "../custom/Help";
-
-// libs
 import normalizeOrigin from "../../lib/normalize-origin";
 
 const { REACT_APP_STAGE } = process.env;
@@ -206,7 +203,8 @@ const GeoJSONMeta = (props: Props) => {
       });
   };
 
-  const saveDisabled = allowedOrigins === ((typeof propOrigins === "string") ? propOrigins: propOrigins.join("\n"))
+  const saveDisabled = 
+    allowedOrigins === ((typeof propOrigins === "string") ? propOrigins: propOrigins.join("\n"))
 
   const onUpdateClick = () => {
     if (saveDisabled || !session) {


### PR DESCRIPTION
GeoJsonMeta に `allowedOrigins` を保存するフォームを追加しました。

気になる点
- `src/components/Data/GeoJson/hooks/use-geojson.ts` でGeoJSONMetaを取得した際、値が保存されているかどうかを`typeof json.allowedOrigins === "string"` でチェックしていましたが、保存されていない場合は ` undefined` が帰ってきたので`typeof json.allowedOrigins !== "undefined"`に変更しました。
  -  https://github.com/geolonia/app.geolonia.com/blob/9657cd12ee6e82b26fcaf995ef1ec1bd70d6497c/src/components/Data/GeoJson/hooks/use-geojson.ts#L47
- public/private のボタンが disabled になっていましたが、AllowedOriginsフォームの表示・非表示のテストのために削除しています。
  - https://github.com/geolonia/app.geolonia.com/pull/363/files#diff-f1464bcef7ac9bffa8c7d62645291a21286f314b2d0ca749751bf0f033fa7bd5L200