### PR TITLE
Draw map after polling

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -4,3 +4,4 @@ REACT_APP_API_BASE="https://api.example.com"
 REACT_APP_APP_API_BASE="https://api.app.example.com"
 REACT_APP_STAGE=dev
 REACT_APP_STRIPE_PUBLISHABLE_KEY=pk_test_zzzzz
+REACT_APP_TILE_SEVER="https://tileserver-dev.geolonia.com"

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -422,6 +422,7 @@ const Content = (props: Props) => {
               style={style}
               drawCallback={drawCallback}
               getNumberFeatures={getNumberFeatures}
+              geojsonId={props.geojsonId}
               geoJSON={geoJSON}
               onClickFeature={onClickFeatureHandler}
               saveCallback={saveFeatureCallback}

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -66,7 +66,7 @@ const Content = (props: Props) => {
   const [drawObject, setDrawObject] = React.useState<MapboxDraw>();
   const [numberFeatures, setNumberFeatures] = React.useState<number>(0);
   const [style, setStyle] = React.useState<string>("geolonia/basic");
-  const [tileStatus, setTileStatus] = React.useState< null | "progress" | "created">(null); // カスタムタイルの生成結果を保存する為に用意。
+  const [tileStatus, setTileStatus] = React.useState< undefined | "progress" | "created" | "failure">(undefined);
 
   // custom hooks
   const {
@@ -319,6 +319,25 @@ const Content = (props: Props) => {
     }
   };
 
+  const getTileStatus = async (session: Geolonia.Session, teamId: string, geojsonId: string ) => {
+    let status: undefined | "progress" | "created" | "failure"
+    while (status !== "created") {
+      try {
+        const res = await fetch(
+          session,
+          buildApiUrl(`/geojsons/${geojsonId}?teamId=${teamId}`),
+          { method: "GET" }
+        )
+        const json = await res.json()
+        status = json.gvp_status
+
+      } catch (error) {
+        throw new Error();
+      }
+    }
+    return status
+  }
+
   if (error) {
     return <></>;
   }
@@ -343,6 +362,7 @@ const Content = (props: Props) => {
             teamId={props.teamId}
             geojsonId={props.geojsonId}
             isPaidTeam={props.isPaidTeam}
+            getTileStatus={getTileStatus}
             setTileStatus={setTileStatus}
           />
         </div>
@@ -438,6 +458,7 @@ const Content = (props: Props) => {
             teamId={props.teamId}
             geojsonId={props.geojsonId}
             isPaidTeam={props.isPaidTeam}
+            getTileStatus={getTileStatus}
             setTileStatus={setTileStatus}
           />
         )}

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -322,7 +322,7 @@ const Content = (props: Props) => {
     return new Promise(resolve => setTimeout(resolve, 1000));
   }
 
-  const getTileStatus = async (session: Geolonia.Session, teamId: string, geojsonId: string ) => {
+  const getTileStatus = React.useCallback( async (session: Geolonia.Session, teamId: string, geojsonId: string ) => {
     let status = "progress"
     while (status !== "created" && status !== "failure") {
       try {
@@ -340,17 +340,19 @@ const Content = (props: Props) => {
       await sleep()
     }
     return status
-  }
+  },[])
+
+  React.useEffect(() => {
+    if (props.teamId && props.geojsonId) {
+      getTileStatus(props.session, props.teamId, props.geojsonId)
+      .then((status: undefined | "progress" | "created" | "failure") => {
+        setTileStatus(status)
+      })
+    }
+  }, [getTileStatus, props.geojsonId, props.session, props.teamId]);
 
   if (error) {
     return <></>;
-  }
-
-  if (props.teamId && props.geojsonId) {
-    getTileStatus(props.session, props.teamId, props.geojsonId)
-    .then((status: undefined | "progress" | "created" | "failure") => {
-      setTileStatus(status)
-    })
   }
 
   return (

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -453,8 +453,16 @@ const Content = (props: Props) => {
                 flexDirection: "column"
               }}
             >
-              <p>{__("Adding your data to map")}</p>
-              <CircularProgress />
+              <>
+                {tileStatus === "failure" ? (
+                  <p>{__("Failed to add your data. Your GeoJSON might be invalid.")}</p>
+                ) : (
+                  <>
+                    <p>{__("Adding your data to map")}</p>
+                    <CircularProgress />
+                  </>
+                )}
+              </>
             </div>
           )}
           </>

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -40,8 +40,6 @@ import "./GeoJson.scss";
 // constants
 import { messageDisplayDuration } from "../../constants";
 import { buildApiUrl } from "../../lib/api";
-import { stat } from "node:fs";
-const { REACT_APP_STAGE } = process.env;
 
 type OwnProps = Record<string, never>;
 

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -455,7 +455,7 @@ const Content = (props: Props) => {
             >
               <>
                 {tileStatus === "failure" ? (
-                  <p>{__("Failed to add your data. Your GeoJSON might be invalid.")}</p>
+                  <p>{__("Failed to add your data. Your GeoJSON might be invalid format.")}</p>
                 ) : (
                   <>
                     <p>{__("Adding your data to map")}</p>

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -319,6 +319,10 @@ const Content = (props: Props) => {
     }
   };
 
+  const sleep = () => {
+    return new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
   const getTileStatus = async (session: Geolonia.Session, teamId: string, geojsonId: string ) => {
     let status: undefined | "progress" | "created" | "failure"
     while (status !== "created") {
@@ -334,6 +338,7 @@ const Content = (props: Props) => {
       } catch (error) {
         throw new Error();
       }
+      await sleep()
     }
     return status
   }

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -65,7 +65,7 @@ const Content = (props: Props) => {
   const [drawObject, setDrawObject] = React.useState<MapboxDraw>();
   const [numberFeatures, setNumberFeatures] = React.useState<number>(0);
   const [style, setStyle] = React.useState<string>("geolonia/basic");
-  const [tileStatus, setTileStatus] = React.useState< undefined | "progress" | "created" | "failure">(undefined);
+  const [tileStatus, setTileStatus] = React.useState< null | undefined | "progress" | "created" | "failure">(null);
 
   // custom hooks
   const {
@@ -343,18 +343,16 @@ const Content = (props: Props) => {
   },[])
 
   React.useEffect(() => {
-    if (props.teamId && props.geojsonId) {
-      getTileStatus(props.session, props.teamId, props.geojsonId)
-      .then((status: undefined | "progress" | "created" | "failure") => {
-        setTileStatus(status)
-      })
+    if (geoJsonMeta) {
+      setTileStatus(geoJsonMeta.gvp_status)
     }
-  }, [getTileStatus, props.geojsonId, props.session, props.teamId]);
+
+  }, [geoJsonMeta]);
 
   if (error) {
     return <></>;
   }
-
+  
   return (
     <div className="gis-panel">
       <Title
@@ -427,17 +425,7 @@ const Content = (props: Props) => {
       ></Snackbar>
 
       <div className="editor">
-        {tileStatus === undefined && 
-          <ImportDropZone
-            session={props.session}
-            teamId={props.teamId}
-            geojsonId={props.geojsonId}
-            isPaidTeam={props.isPaidTeam}
-            getTileStatus={getTileStatus}
-            setTileStatus={setTileStatus}
-          />
-        }
-        {tileStatus === "progress" &&
+        {tileStatus === null ? (
           <div
             style={{
             width: "100%",
@@ -448,33 +436,23 @@ const Content = (props: Props) => {
             flexDirection: "column"
           }}
           >
-            <p>{__("Adding your data to map")}</p>
             <CircularProgress />
           </div>
-        }
-        {tileStatus === "created" &&
+        ) : (
           <>
-            <MapEditor
-              style={style}
-              drawCallback={drawCallback}
-              getNumberFeatures={getNumberFeatures}
+          {tileStatus === undefined && 
+            <ImportDropZone
+              session={props.session}
+              teamId={props.teamId}
               geojsonId={props.geojsonId}
-              geoJSON={geoJSON}
-              onClickFeature={onClickFeatureHandler}
-              saveCallback={saveFeatureCallback}
-              bounds={bounds}
+              isPaidTeam={props.isPaidTeam}
+              getTileStatus={getTileStatus}
+              setTileStatus={setTileStatus}
             />
-            {currentFeature && 
-              <PropsEditor
-                currentFeature={currentFeature}
-                updateFeatureProperties={updateFeatureProps}
-              />
-            }
-          </>
-        }
-        {tileStatus === "failure" &&
-          <div
-            style={{
+          }
+          {tileStatus === "progress" &&
+            <div
+              style={{
               width: "100%",
               height: "100%",
               display: "flex",
@@ -482,10 +460,47 @@ const Content = (props: Props) => {
               alignItems: "center",
               flexDirection: "column"
             }}
-          >
-            <p>{__("Failed to add your data. Your GeoJSON might be invalid format.")}</p>
-          </div>
-        }
+            >
+              <p>{__("Adding your data to map")}</p>
+              <CircularProgress />
+            </div>
+          }
+          {tileStatus === "created" &&
+            <>
+              <MapEditor
+                style={style}
+                drawCallback={drawCallback}
+                getNumberFeatures={getNumberFeatures}
+                geojsonId={props.geojsonId}
+                geoJSON={geoJSON}
+                onClickFeature={onClickFeatureHandler}
+                saveCallback={saveFeatureCallback}
+                bounds={bounds}
+              />
+              {currentFeature && 
+                <PropsEditor
+                  currentFeature={currentFeature}
+                  updateFeatureProperties={updateFeatureProps}
+                />
+              }
+            </>
+          }
+          {tileStatus === "failure" &&
+            <div
+              style={{
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                flexDirection: "column"
+              }}
+            >
+              <p>{__("Failed to add your data. Your GeoJSON might be invalid format.")}</p>
+            </div>
+          }
+          </>
+        )}
       </div>
 
       <div className="number-features">

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -11,6 +11,7 @@ type GeoJSONMeta = {
   isPublic: boolean;
   allowedOrigins: string[];
   status: string;
+  gvp_status?: undefined | "progress" | "created" | "failure"
 };
 
 export default function useGeoJSON(

--- a/src/components/Data/ImportDropZone.tsx
+++ b/src/components/Data/ImportDropZone.tsx
@@ -80,7 +80,7 @@ const Content = (props: Props) => {
     uploadGeoJson(acceptedFiles[0], props.session, props.teamId, props.geojsonId)
     setError(null)
     props.setTileStatus("progress") // NOTE: 最初のレスポンスまでに時間がかかるので、progress をセット。
-    props.getTileStatus(props.session, props.teamId, props.geojsonId, props.setTileStatus)
+    props.getTileStatus(props.session, props.teamId, props.geojsonId)
       .then((status: undefined | "progress" | "created" | "failure") => {
         props.setTileStatus(status)
       })

--- a/src/components/Data/ImportDropZone.tsx
+++ b/src/components/Data/ImportDropZone.tsx
@@ -36,6 +36,7 @@ const uploadGeoJson = (geojson: File, session: Geolonia.Session, teamId?: string
 }
 
 type Props = {
+  getTileStatus: Function,
   setTileStatus: Function,
   session: Geolonia.Session,
   isPaidTeam: boolean,
@@ -78,9 +79,11 @@ const Content = (props: Props) => {
 
     uploadGeoJson(acceptedFiles[0], props.session, props.teamId, props.geojsonId)
     setError(null)
-    props.setTileStatus("progress")
-
-    setTimeout(()=>{props.setTileStatus("created")}, 1000) // TODO: デバッグ用に追加。後で削除する。
+    props.setTileStatus("progress") // NOTE: 最初のレスポンスまでに時間がかかるので、progress をセット。
+    props.getTileStatus(props.session, props.teamId, props.geojsonId, props.setTileStatus)
+      .then((status: undefined | "progress" | "created" | "failure") => {
+        props.setTileStatus(status)
+      })
 
   }, [props])
 

--- a/src/components/Data/ImportDropZoneButton.tsx
+++ b/src/components/Data/ImportDropZoneButton.tsx
@@ -5,6 +5,7 @@ import { __ } from "@wordpress/i18n"
 import "./ImportDropZoneButton.scss"
 
 type Props = {
+  getTileStatus: Function,
   setTileStatus: Function,
   session: Geolonia.Session,
   isPaidTeam: boolean,
@@ -60,6 +61,7 @@ const Content = (props: Props) => {
               teamId={props.teamId}
               geojsonId={props.geojsonId}
               isPaidTeam={props.isPaidTeam}
+              getTileStatus={props.getTileStatus}
               setTileStatus={props.setTileStatus}
             />
           </div>

--- a/src/components/Data/MapEditor.tsx
+++ b/src/components/Data/MapEditor.tsx
@@ -11,6 +11,7 @@ import centroid from "@turf/centroid";
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 
 type OwnProps = {
+  geojsonId: string | undefined;
   geoJSON: GeoJSON.FeatureCollection | undefined;
   onClickFeature: Function;
   drawCallback: Function;
@@ -46,7 +47,7 @@ const createMapEvents = (props: Props, map: mapboxgl.Map) => {
 };
 
 export const MapEditor = (props: Props) => {
-  const { geoJSON, drawCallback, getNumberFeatures, bounds, style } = props;
+  const { geojsonId, geoJSON, drawCallback, getNumberFeatures, bounds, style } = props;
 
   // mapbox map and draw binding
   const [map, setMap] = React.useState<mapboxgl.Map | undefined>(undefined);
@@ -142,6 +143,7 @@ export const MapEditor = (props: Props) => {
         navigationControl={"off"}
         onAfterLoad={handleOnAfterLoad}
         bounds={bounds}
+        geojsonId={geojsonId}
       />
     </div>
   );

--- a/src/components/Data/MapEditor.tsx
+++ b/src/components/Data/MapEditor.tsx
@@ -9,6 +9,7 @@ import fullscreen from "./fullscreenMap";
 import centroid from "@turf/centroid";
 // @ts-ignore
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
+const {REACT_APP_TILE_SEVER} = process.env
 
 type OwnProps = {
   geojsonId: string | undefined;
@@ -81,7 +82,15 @@ export const MapEditor = (props: Props) => {
     }
   }, [map, style]);
 
-  const handleOnAfterLoad = (map: mapboxgl.Map) => {
+  const handleOnAfterLoad = async (map: mapboxgl.Map) => {
+
+    const res = await fetch(`${REACT_APP_TILE_SEVER}/customtiles/${geojsonId}/tiles.json?key=YOUR-API-KEY`)
+    const tileJson = await res.json()
+    map.fitBounds(tileJson.bounds, {
+      padding: 20,
+      maxZoom: 16,
+    })
+    
     const draw: MapboxDraw = new MapboxDraw({
       boxSelect: true,
       controls: {

--- a/src/components/custom/GeoloniaMap.tsx
+++ b/src/components/custom/GeoloniaMap.tsx
@@ -3,6 +3,7 @@ import React from "react";
 type Toggle = "on" | "off";
 
 type Props = {
+  geojsonId: string | undefined;
   width: string;
   height: string;
   gestureHandling: Toggle;
@@ -44,6 +45,7 @@ class Map extends React.Component<Props, State> {
     geolocateControl: "off",
     navigationControl: "off",
     style: null,
+    simpleVector: null,
     onAfterLoad: () => {}
   };
 
@@ -78,6 +80,7 @@ class Map extends React.Component<Props, State> {
         data-navigation-control={this.props.navigationControl}
         data-fullscreen-control={this.props.fullscreenControl}
         data-geolocate-control={this.props.geolocateControl}
+        data-simple-vector={`https://tileserver.geolonia.com/customtiles/${this.props.geojsonId}/tiles.json`}
       />
     );
   }

--- a/src/components/custom/GeoloniaMap.tsx
+++ b/src/components/custom/GeoloniaMap.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+const { REACT_APP_STAGE } = process.env;
 
 type Toggle = "on" | "off";
 
@@ -25,6 +26,7 @@ type State = {
 class Map extends React.Component<Props, State> {
   style: React.CSSProperties = {};
   container = React.createRef<HTMLDivElement>();
+  tileserverHost: string = REACT_APP_STAGE === "v1" ? "tileserver.geolonia.com" : "tileserver-dev.geolonia.com"
 
   constructor(props: Props) {
     super(props);
@@ -80,7 +82,7 @@ class Map extends React.Component<Props, State> {
         data-navigation-control={this.props.navigationControl}
         data-fullscreen-control={this.props.fullscreenControl}
         data-geolocate-control={this.props.geolocateControl}
-        data-simple-vector={`https://tileserver.geolonia.com/customtiles/${this.props.geojsonId}/tiles.json`}
+        data-simple-vector={`https://${this.tileserverHost}/customtiles/${this.props.geojsonId}/tiles.json?key=YOUR-API-KEY`}
       />
     );
   }

--- a/src/components/custom/GeoloniaMap.tsx
+++ b/src/components/custom/GeoloniaMap.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-const { REACT_APP_STAGE } = process.env;
+const { REACT_APP_STAGE, REACT_APP_TILE_SEVER } = process.env;
 
 type Toggle = "on" | "off";
 
@@ -26,7 +26,6 @@ type State = {
 class Map extends React.Component<Props, State> {
   style: React.CSSProperties = {};
   container = React.createRef<HTMLDivElement>();
-  tileserverHost: string = REACT_APP_STAGE === "v1" ? "tileserver.geolonia.com" : "tileserver-dev.geolonia.com"
 
   constructor(props: Props) {
     super(props);
@@ -82,7 +81,7 @@ class Map extends React.Component<Props, State> {
         data-navigation-control={this.props.navigationControl}
         data-fullscreen-control={this.props.fullscreenControl}
         data-geolocate-control={this.props.geolocateControl}
-        data-simple-vector={`https://${this.tileserverHost}/customtiles/${this.props.geojsonId}/tiles.json?key=YOUR-API-KEY`}
+        data-simple-vector={`${REACT_APP_TILE_SEVER}/customtiles/${this.props.geojsonId}/tiles.json?key=YOUR-API-KEY`}
       />
     );
   }


### PR DESCRIPTION
Closes #351 

カスタムタイル生成後にダッシュボードで地図を表示する機能を実装しました。

実装内容

- 1秒ごとにポーリングして、`"gvp_status": "created"` 時に`data-simple-vector` にタイルのURLを指定。
- タイルの生成失敗時のメッセージ追加