### PR TITLE
Dashboard fixes

### DIFF
--- a/src/components/Data/GeoJsons.tsx
+++ b/src/components/Data/GeoJsons.tsx
@@ -48,70 +48,67 @@ type typeTableRows = {
 function Content(props: Props) {
   const [message, setMessage] = useState("");
   const [geoJsons, setGeoJsons] = useState<typeTableRows[]>([]);
-  // watchDog monitors successful POST request and force refresh.
-  const [watchdog, setWatchdog] = useState(0);
   const [perPage, setPerPage] = useState(1000);
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(false);
 
+  const { teamId, session, history } = props;
+
   const page = Number(queryString.parse(props.location.search).page) || 0;
   useEffect(() => {
-    if (props.teamId && props.session) {
-      setLoading(true);
-      fetch(
-        props.session,
-        buildApiUrl(`/geojsons?teamId=${props.teamId}&per_page=${perPage}&page=${page}`)
-      )
-        .then(res => {
-          if (res.status < 300) {
-            return res.json();
-          } else {
-            throw new Error();
-          }
-        })
-        .then(json => {
-          const { totalCount, geojsons } = json;
-
-          if (perPage * page > totalCount) {
-            props.history.push("?page=0");
-            return;
-          }
-
-          const rows = [];
-          for (let i = 0; i < geojsons.length; i++) {
-            // const item = dateParse<DateStringify<any>>(json[i]);
-            const geojson = geojsons[i];
-            rows.push({
-              id: geojson.id,
-              name: geojson.name,
-              updated: Moment(geojson.updateAt).format(),
-              isPublic: geojson.isPublic
-            } as typeTableRows);
-          }
-          setTotalCount(totalCount);
-          setGeoJsons(
-            rows.sort((a: typeTableRows, b: typeTableRows) => {
-              if (a.updated > b.updated) {
-                return -1;
-              } else {
-                return 1;
-              }
-            })
-          );
-        })
-        .catch(err => {
-          alert(__("Network Error."));
-        })
-        .finally(() => setLoading(false));
+    if (!teamId || !session) {
+      return;
     }
+
+    (async () => {
+      setLoading(true);
+      const rawResp = await fetch(
+        session,
+        buildApiUrl(`/geojsons?teamId=${teamId}&per_page=${perPage}&page=${page}`)
+      );
+      if (rawResp.status >= 300) {
+        alert(__("Network Error."));
+        setLoading(false);
+        return;
+      }
+
+      const json = await rawResp.json();
+      const { totalCount, geojsons } = json;
+      if (perPage * page > totalCount) {
+        history.push("?page=0");
+        return;
+      }
+
+      const rows = [];
+      for (let i = 0; i < geojsons.length; i++) {
+        // const item = dateParse<DateStringify<any>>(json[i]);
+        const geojson = geojsons[i];
+        rows.push({
+          id: geojson.id,
+          name: geojson.name,
+          updated: Moment(geojson.updateAt).format(),
+          isPublic: geojson.isPublic
+        } as typeTableRows);
+      }
+      setTotalCount(totalCount);
+      setGeoJsons(
+        rows.sort((a: typeTableRows, b: typeTableRows) => {
+          if (a.updated > b.updated) {
+            return -1;
+          } else {
+            return 1;
+          }
+        })
+      );
+      setLoading(false);
+    })();
   }, [
-    props.teamId,
-    props.session,
-    watchdog,
+    teamId,
+    session,
     props.location.search,
     page,
     perPage,
-    props.history
+    history,
   ]);
 
   const breadcrumbItems = [
@@ -126,40 +123,27 @@ function Content(props: Props) {
   ];
 
   const createHandler = useCallback(async (name: string) => {
-    const { teamId, session } = props;
-    if (!(teamId && session)) {
-      return Promise.resolve();
+    if (!teamId || !session) {
+      return;
     }
 
-    return fetch(
-      props.session,
+    const rawResp = await fetch(
+      session,
       buildApiUrl(`/geojsons?teamId=${teamId}`),
       {
         method: "POST",
         body: JSON.stringify({ name })
       }
-    )
-      .then(res => {
-        if (res.status < 300) {
-          return res.json();
-        } else {
-          throw new Error();
-        }
-      })
-      .then(() => {
-        // wait until the Elasticsearch completes indexing
-        return new Promise<void>(resolve => {
-          setTimeout(() => {
-            setWatchdog((oldWatchdog) => oldWatchdog + 1);
-            resolve();
-          }, 1500);
-        });
-      })
-      .catch(() => {
-        setMessage(__("Network error."));
-        throw new Error(); // will be caught by <AddNew />
-      });
-  }, [props]);
+    );
+    if (rawResp.status >= 300) {
+      setMessage(__("Network error."));
+      throw new Error();
+    }
+    const resp = await rawResp.json();
+    const newId = resp.body._id;
+    history.push(`/data/geojson/${newId}`);
+
+  }, [session, history, teamId]);
 
   return (
     <div>

--- a/src/components/Data/GeoJsons.tsx
+++ b/src/components/Data/GeoJsons.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 // components
 import AsyncTable from "../custom/AsyncTable";
@@ -46,16 +46,16 @@ type typeTableRows = {
 };
 
 function Content(props: Props) {
-  const [message, setMessage] = React.useState("");
-  const [geoJsons, setGeoJsons] = React.useState<typeTableRows[]>([]);
+  const [message, setMessage] = useState("");
+  const [geoJsons, setGeoJsons] = useState<typeTableRows[]>([]);
   // watchDog monitors successful POST request and force refresh.
-  const [watchdog, setWatchdog] = React.useState(0);
-  const [perPage, setPerPage] = React.useState(10);
-  const [totalCount, setTotalCount] = React.useState(0);
-  const [loading, setLoading] = React.useState(false);
+  const [watchdog, setWatchdog] = useState(0);
+  const [perPage, setPerPage] = useState(1000);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(false);
 
   const page = Number(queryString.parse(props.location.search).page) || 0;
-  React.useEffect(() => {
+  useEffect(() => {
     if (props.teamId && props.session) {
       setLoading(true);
       fetch(
@@ -125,7 +125,7 @@ function Content(props: Props) {
     }
   ];
 
-  const handler = (name: string) => {
+  const createHandler = useCallback(async (name: string) => {
     const { teamId, session } = props;
     if (!(teamId && session)) {
       return Promise.resolve();
@@ -150,7 +150,7 @@ function Content(props: Props) {
         // wait until the Elasticsearch completes indexing
         return new Promise<void>(resolve => {
           setTimeout(() => {
-            setWatchdog(watchdog + 1);
+            setWatchdog((oldWatchdog) => oldWatchdog + 1);
             resolve();
           }, 1500);
         });
@@ -159,7 +159,7 @@ function Content(props: Props) {
         setMessage(__("Network error."));
         throw new Error(); // will be caught by <AddNew />
       });
-  };
+  }, [props]);
 
   return (
     <div>
@@ -173,7 +173,7 @@ function Content(props: Props) {
         label={__("Create a new dataset")}
         description={__("Please enter the name of the new dataset.")}
         defaultValue={__("My dataset")}
-        onClick={handler}
+        onClick={createHandler}
         errorMessage={message}
       />
 


### PR DESCRIPTION
#348 

* GeoJSON作成にエンターを押すと作成できるように
* アップロード時にファイルサイズリミットを正しく（以前は有料チームでも1MBと表示されていた）
* customtiles tiles.jsonのリクエストを統一（sources loaded のイベントを拾って zoom to bounds するように変更）
* トークンが valid じゃない時は、トークンを更新してから地図を読み込む
* GeoJSON作成後一覧に戻る挙動から、新規作成されたGeoJSONの詳細にページ遷移する
* もろもろリファクタリング