### PR TITLE
他のチームの GeoJSON のページにアクセスできないように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build:ci": "react-scripts build && bin/postbuild.sh",
     "cname": "echo $CNAME > ./build/CNAME",
     "test": "react-scripts test",
-    "lint": "eslint --ext .tsx --ext .ts --ext .jsx --ext .js .",
+    "lint": "eslint --ext .tsx --ext .ts --ext .jsx --ext .js src",
     "eject": "react-scripts eject",
     "makepot": "node_modules/@babel/cli/bin/babel.js ./src -x '.tsx' -x '.ts' --config-file ./.babelrc.i18n",
     "msgmerge": "msgmerge -U src/lang/ja.po src/lang/lang.pot --lang=ja",

--- a/src/components/AcceptInvitation.tsx
+++ b/src/components/AcceptInvitation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Snackbar from "@material-ui/core/Snackbar";
 import Button from "@material-ui/core/Button";
 
@@ -16,7 +16,7 @@ type RouterProps = {
 type Props = OwnProps & RouterProps;
 
 const useInvitationAcceptRequest = (props: Props) => {
-  const [status, setStatus] = React.useState<
+  const [status, setStatus] = useState<
     false | "success" | "failure" | "requesting"
   >(false);
 
@@ -27,7 +27,7 @@ const useInvitationAcceptRequest = (props: Props) => {
     }
   } = props;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isReady && status === false) {
       setStatus("requesting");
       fetch(

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -50,9 +50,17 @@ const sleep = (msec: number) => {
 }
 
 const Content = (props: Props) => {
+  const {
+    session,
+    teamId,
+    geojsonId,
+    history,
+  } = props;
+
   const [message] = useState("");
   const [style, setStyle] = useState<string>("geolonia/basic");
   const [tileStatus, setTileStatus] = useState<TileStatus>(null);
+  const [prevTeamId] = useState(teamId);
 
   // custom hooks
   const {
@@ -62,11 +70,12 @@ const Content = (props: Props) => {
     error
   } = useGeoJSON(props.session, props.geojsonId);
 
-  const {
-    session,
-    teamId,
-    geojsonId,
-  } = props;
+// move on team change
+  React.useEffect(() => {
+    if (prevTeamId !== teamId) {
+      history.push("/data/geojson");
+    }
+  }, [prevTeamId, history, teamId]);
 
   const breadcrumbItems = [
     {
@@ -140,6 +149,10 @@ const Content = (props: Props) => {
 
   }, [geoJsonMeta]);
 
+  // invalid url entered
+  if (geoJsonMeta && geoJsonMeta.teamId !== teamId) {
+    return <></>;
+  }
   if (error) {
     return <></>;
   }
@@ -192,6 +205,7 @@ const Content = (props: Props) => {
     </div>;
   }
 
+
   return (
     <div className="gis-panel">
       <Title
@@ -229,6 +243,7 @@ const Content = (props: Props) => {
             name={geoJsonMeta.name}
             isPublic={geoJsonMeta.isPublic}
             allowedOrigins={geoJsonMeta.allowedOrigins}
+            teamId={geoJsonMeta.teamId}
             status={geoJsonMeta.status}
             setGeoJsonMeta={setGeoJsonMeta}
             style={style}

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -71,7 +71,7 @@ const Content = (props: Props) => {
   } = useGeoJSON(props.session, props.geojsonId);
 
 // move on team change
-  React.useEffect(() => {
+  useEffect(() => {
     if (prevTeamId !== teamId) {
       history.push("/data/geojson");
     }
@@ -151,10 +151,10 @@ const Content = (props: Props) => {
 
   // invalid url entered
   if (geoJsonMeta && geoJsonMeta.teamId !== teamId) {
-    return <></>;
+    return null;
   }
   if (error) {
-    return <></>;
+    return null;
   }
 
   let mapEditorElement: JSX.Element = <></>;

--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -157,7 +157,7 @@ const Content = (props: Props) => {
     return null;
   }
 
-  let mapEditorElement: JSX.Element = <></>;
+  let mapEditorElement: JSX.Element | null = null;
   if (tileStatus === null || tileStatus === "progress") {
     mapEditorElement = <div
       style={{
@@ -236,8 +236,7 @@ const Content = (props: Props) => {
         {mapEditorElement}
       </div>
 
-      {props.geojsonId && geoJsonMeta ? (
-        <div className="geojson-meta">
+      {props.geojsonId && geoJsonMeta && <div className="geojson-meta">
           <GeoJsonMeta
             geojsonId={props.geojsonId}
             name={geoJsonMeta.name}
@@ -250,9 +249,7 @@ const Content = (props: Props) => {
             isPaidTeam={props.isPaidTeam}
           />
         </div>
-      ) : (
-        <></>
-      )}
+      }
 
       <DangerZone
         whyDanger={__(

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -53,27 +53,27 @@ export default function useGeoJSON(
         })
         .catch(() => setError(true));
 
-      // // get Features
-      // fetch(
-      //   session,
-      //   `https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/${geojsonId}/features`
-      // )
-      //   .then(res => {
-      //     if (res.status < 400) {
-      //       return res.json();
-      //     } else {
-      //       throw new Error();
-      //     }
-      //   })
-      //   .then(json => {
-      //     const geojson = {
-      //       type: "FeatureCollection",
-      //       features: json.features
-      //     } as GeoJSON.FeatureCollection;
-      //     setGeoJSON(geojson);
-      //     setBounds(geojsonExtent(geojson));
-      //   })
-      //   .catch(() => setError(true));
+      // get Features
+      fetch(
+        session,
+        `https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/${geojsonId}/features`
+      )
+        .then(res => {
+          if (res.status < 400) {
+            return res.json();
+          } else {
+            throw new Error();
+          }
+        })
+        .then(json => {
+          const geojson = {
+            type: "FeatureCollection",
+            features: json.features
+          } as GeoJSON.FeatureCollection;
+          setGeoJSON(geojson);
+          setBounds(geojsonExtent(geojson));
+        })
+        .catch(() => setError(true));
     }
   }, [session, geojsonId]);
 

--- a/src/components/Data/GeoJson/hooks/use-geojson.ts
+++ b/src/components/Data/GeoJson/hooks/use-geojson.ts
@@ -11,7 +11,8 @@ type GeoJSONMeta = {
   isPublic: boolean;
   allowedOrigins: string[];
   status: string;
-  gvp_status?: undefined | "progress" | "created" | "failure"
+  gvp_status?: undefined | "progress" | "created" | "failure",
+  teamId: string;
 };
 
 export type GeoJsonMetaSetter = React.Dispatch<React.SetStateAction<GeoJSONMeta | null>>;
@@ -52,27 +53,27 @@ export default function useGeoJSON(
         })
         .catch(() => setError(true));
 
-      // get Features
-      fetch(
-        session,
-        `https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/${geojsonId}/features`
-      )
-        .then(res => {
-          if (res.status < 400) {
-            return res.json();
-          } else {
-            throw new Error();
-          }
-        })
-        .then(json => {
-          const geojson = {
-            type: "FeatureCollection",
-            features: json.features
-          } as GeoJSON.FeatureCollection;
-          setGeoJSON(geojson);
-          setBounds(geojsonExtent(geojson));
-        })
-        .catch(() => setError(true));
+      // // get Features
+      // fetch(
+      //   session,
+      //   `https://api.geolonia.com/${REACT_APP_STAGE}/geojsons/${geojsonId}/features`
+      // )
+      //   .then(res => {
+      //     if (res.status < 400) {
+      //       return res.json();
+      //     } else {
+      //       throw new Error();
+      //     }
+      //   })
+      //   .then(json => {
+      //     const geojson = {
+      //       type: "FeatureCollection",
+      //       features: json.features
+      //     } as GeoJSON.FeatureCollection;
+      //     setGeoJSON(geojson);
+      //     setBounds(geojsonExtent(geojson));
+      //   })
+      //   .catch(() => setError(true));
     }
   }, [session, geojsonId]);
 

--- a/src/components/Data/GeoJsonImporter.tsx
+++ b/src/components/Data/GeoJsonImporter.tsx
@@ -110,7 +110,7 @@ const Importer: React.FC<Props> = (props) => {
   <p>{__("Import GeoJSON from your computer.")}<br />({sprintf(__('Maximum upload file size: %d MB'), GeoJsonMaxUploadSize / 1000000)})</p>
         <p><input type="file" accept='.json,.geojson' onChange={handleFileUpload} /></p>
         <p>{__("Existing feature that has same `id` will be updated.")}</p>
-        {error? <div className="error">{error}</div> : <></>}
+        {error && <div className="error">{error}</div>}
       </div>
     </div>
   );

--- a/src/components/Data/GeoJsonImporter.tsx
+++ b/src/components/Data/GeoJsonImporter.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import { GeoJsonMaxUploadSize } from "../../constants";
@@ -32,10 +32,10 @@ const styleOuterDefault: React.CSSProperties = {
 
 const Importer: React.FC<Props> = (props) => {
   const {state, onClose, GeoJsonImporter} = props;
-  const [styleOuter, setStyleOuter] = React.useState<React.CSSProperties>(styleOuterDefault)
-  const [error, setError] = React.useState<string | null>(null)
+  const [styleOuter, setStyleOuter] = useState<React.CSSProperties>(styleOuterDefault)
+  const [error, setError] = useState<string | null>(null)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const style = {...styleOuterDefault}
     if (state) {
       style.display = 'flex'

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -181,7 +181,7 @@ const GeoJSONMeta = (props: Props) => {
   const [saveStatus, setSaveStatus] = useState<false | "requesting" | "success" | "failure">(false);
   const onRequestError = () => setSaveStatus("failure");
 
-  React.useEffect(() => {
+  useEffect(() => {
     const script = document.createElement("script");
     script.src = "https://geolonia.github.io/get-geolonia/app.js";
     document.body.appendChild(script);
@@ -218,7 +218,7 @@ const GeoJSONMeta = (props: Props) => {
     }
     // const resp = await rawResp.json();
     setGeoJsonMeta({ isPublic, name: draftName, allowedOrigins, status, teamId });
-  }, [allowedOrigins, geojsonId, isPublic, session, setGeoJsonMeta, status]);
+  }, [allowedOrigins, geojsonId, isPublic, session, setGeoJsonMeta, status, teamId]);
 
   let saveDisabled = false
 
@@ -264,7 +264,7 @@ const GeoJSONMeta = (props: Props) => {
         setSaveStatus("success");
         setGeoJsonMeta({ isPublic, name, allowedOrigins: normalizedAllowedOrigins, status, teamId });
       });
-  }, [draftAllowedOrigins, geojsonId, isPublic, name, saveDisabled, session, status, setGeoJsonMeta])
+  }, [draftAllowedOrigins, geojsonId, isPublic, name, saveDisabled, session, status, setGeoJsonMeta, teamId])
 
   return (
     <Grid className="geojson-meta" container spacing={2}>

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -29,6 +29,7 @@ type OwnProps = {
   isPublic: boolean;
   allowedOrigins: string[];
   status: string;
+  teamId: string;
   setGeoJsonMeta: GeoJsonMetaSetter;
 
   isPaidTeam: boolean;
@@ -107,6 +108,7 @@ const usePublic = (
         allowedOrigins: resp.body._source.allowedOrigins,
         status: resp.body._source.status,
         gvp_status: resp.body._source.gvp_status,
+        teamId: resp.body._source.teamId,
       });
     })();
   }, [
@@ -155,6 +157,7 @@ const useStatus = (
         allowedOrigins: resp.body._source.allowedOrigins,
         status: resp.body._source.status,
         gvp_status: resp.body._source.gvp_status,
+        teamId: resp.body._source.teamId,
       });
     })();
   }, [
@@ -166,7 +169,7 @@ const useStatus = (
 
 const GeoJSONMeta = (props: Props) => {
   // サーバーから取得してあるデータ
-  const { geojsonId, name, isPublic, allowedOrigins, status } = props;
+  const { geojsonId, name, isPublic, allowedOrigins, status, teamId } = props;
   const { session, setGeoJsonMeta } = props;
 
   // UI上での変更をリクエスト前まで保持しておくための State
@@ -214,7 +217,7 @@ const GeoJSONMeta = (props: Props) => {
       throw new Error();
     }
     // const resp = await rawResp.json();
-    setGeoJsonMeta({ isPublic, name: draftName, allowedOrigins, status });
+    setGeoJsonMeta({ isPublic, name: draftName, allowedOrigins, status, teamId });
   }, [allowedOrigins, geojsonId, isPublic, session, setGeoJsonMeta, status]);
 
   let saveDisabled = false
@@ -259,7 +262,7 @@ const GeoJSONMeta = (props: Props) => {
       })
       .then(() => {
         setSaveStatus("success");
-        setGeoJsonMeta({ isPublic, name, allowedOrigins: normalizedAllowedOrigins, status });
+        setGeoJsonMeta({ isPublic, name, allowedOrigins: normalizedAllowedOrigins, status, teamId });
       });
   }, [draftAllowedOrigins, geojsonId, isPublic, name, saveDisabled, session, status, setGeoJsonMeta])
 

--- a/src/components/Data/ImportButton.tsx
+++ b/src/components/Data/ImportButton.tsx
@@ -23,7 +23,7 @@ const Content = (props: Props) => {
   return (
     <>
       <button className="btn" onClick={() => setStateImporter(true)}><CloudUploadIcon fontSize="small" /><span className="label">{__("Import GeoJSON")}</span></button>
-      {stateImporter? <Importer state={stateImporter} onClose={closeImporter} GeoJsonImporter={GeoJsonImporter} />: <></>}
+      {stateImporter && <Importer state={stateImporter} onClose={closeImporter} GeoJsonImporter={GeoJsonImporter} />}
     </>
   );
 };

--- a/src/components/Data/ImportButton.tsx
+++ b/src/components/Data/ImportButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import Importer from './GeoJsonImporter'
@@ -9,7 +9,7 @@ type Props = {
 };
 
 const Content = (props: Props) => {
-  const [stateImporter, setStateImporter] = React.useState<boolean>(false)
+  const [stateImporter, setStateImporter] = useState<boolean>(false)
 
   const closeImporter = () => {
     setStateImporter(false)

--- a/src/components/Data/ImportDropZone.tsx
+++ b/src/components/Data/ImportDropZone.tsx
@@ -95,7 +95,7 @@ const Content = (props: Props) => {
             <p>{__("Drag and drop a file here to add your map,")}<br />{__("Or click to choose your file")}</p>
           </>
         )}
-        {error? <div className="error">{error}</div> : <></>}
+        {error && <div className="error">{error}</div>}
       </div>
     </Paper>
   )

--- a/src/components/Data/ImportDropZoneButton.tsx
+++ b/src/components/Data/ImportDropZoneButton.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import ImportDropZone from "./ImportDropZone"
 import CloudUploadIcon from '@material-ui/icons/CloudUpload'
 import { __ } from "@wordpress/i18n"
@@ -30,10 +30,10 @@ const styleOuterDefault: React.CSSProperties = {
 }
 
 const Content = (props: Props) => {
-  const [stateImporter, setStateImporter] = React.useState<boolean>(false)
-  const [styleOuter, setStyleOuter] = React.useState<React.CSSProperties>(styleOuterDefault)
+  const [stateImporter, setStateImporter] = useState<boolean>(false)
+  const [styleOuter, setStyleOuter] = useState<React.CSSProperties>(styleOuterDefault)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const style = {...styleOuterDefault}
     if (stateImporter) {
       style.display = 'flex'

--- a/src/components/Data/ImportDropZoneButton.tsx
+++ b/src/components/Data/ImportDropZoneButton.tsx
@@ -53,7 +53,10 @@ const Content = (props: Props) => {
 
   return (
     <>
-      <button className="btn" onClick={() => setStateImporter(true)}><CloudUploadIcon fontSize="small" /><span className="label">{__("Import GeoJSON")}</span></button>
+      <button className="btn" onClick={() => setStateImporter(true)}>
+        <CloudUploadIcon fontSize="small" />
+        <span className="label">{__("Import GeoJSON")}</span>
+      </button>
       {stateImporter ? (
         <div className="geojson-importer geojson-dropzone-button" style={styleOuter} onClick={close}>
           <div className="inner" onClick={preventClose}>
@@ -67,9 +70,7 @@ const Content = (props: Props) => {
             />
           </div>
         </div>
-      ) : (
-      <></>
-      )}
+      ) : null}
     </>
   );
 };

--- a/src/components/Data/StyleSelector.tsx
+++ b/src/components/Data/StyleSelector.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import { MapStylesAPI } from '../../constants'
 
@@ -8,9 +8,9 @@ type Props = {
 };
 
 const Content = (props: Props) => {
-  const [styles, setStyles] = React.useState<[]>([])
+  const [styles, setStyles] = useState<[]>([])
 
-  React.useEffect(() => {
+  useEffect(() => {
     fetch(MapStylesAPI)
       .then(res => res.json())
       .then(json => {

--- a/src/components/Data/text-editor.tsx
+++ b/src/components/Data/text-editor.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 
 type Props = {
@@ -18,10 +18,10 @@ const TextArea = styled.textarea<StyledProps>`
 
 export const TextEditor = (props: Props) => {
   const { geoJSON, setGeoJSON } = props;
-  const [draft, setDraft] = React.useState("");
-  const [error, setError] = React.useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setDraft(JSON.stringify(geoJSON, null, 2));
   }, [geoJSON]);
 

--- a/src/components/Data/upload.tsx
+++ b/src/components/Data/upload.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import CloudUploadIcon from "@material-ui/icons/CloudUpload";
 import Button from "@material-ui/core/Button";
 import { readFile } from "../../lib/read-file";
@@ -13,7 +13,7 @@ type Props = {
 };
 
 export const Upload = (props: Props) => {
-  const [error, setError] = React.useState(false);
+  const [error, setError] = useState(false);
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setError(false);
     if (e.target.files && e.target.files.length > 0) {

--- a/src/components/DeveloperBlog.tsx
+++ b/src/components/DeveloperBlog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
@@ -34,7 +34,7 @@ const useStyles = makeStyles({
 });
 
 const Content = (props: Props) => {
-  const [blogItems, setBlogItems] = React.useState<BlogPost[]>([])
+  const [blogItems, setBlogItems] = useState<BlogPost[]>([])
   const classes = useStyles();
 
   useEffect(() => {

--- a/src/components/ForgotPassword.tsx
+++ b/src/components/ForgotPassword.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import Button from "@material-ui/core/Button";
 import { __ } from "@wordpress/i18n";
@@ -24,11 +24,11 @@ type DispatchProps = Record<string, never>;
 type Props = OwnProps & RouterProps & DispatchProps;
 
 const Content = (props: Props) => {
-  const [email, setEmail] = React.useState("");
-  const [status, setStatus] = React.useState<
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<
     null | "requesting" | "success" | "warning"
   >(null);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   const handleSignup = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import AppBar from "@material-ui/core/AppBar";
 import Grid from "@material-ui/core/Grid";
 import Hidden from "@material-ui/core/Hidden";
@@ -55,7 +55,7 @@ type Props = OwnProps & StateProps;
 
 const Header = (props: Props) => {
   const { classes, onDrawerToggle } = props;
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const headerStyle: React.CSSProperties = {
     backgroundColor: "#EE5F28"

--- a/src/components/Maps/APIKey.tsx
+++ b/src/components/Maps/APIKey.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import * as clipboard from "clipboard-polyfill";
 
 import Grid from "@material-ui/core/Grid";
@@ -55,16 +55,16 @@ type Props = OwnProps & StateProps & DispatchProps & RouterProps;
 
 const Content = (props: Props) => {
   // state
-  const [name, setName] = React.useState("");
-  const [allowedOrigins, setAllowedOrigins] = React.useState("");
-  const [status, setStatus] = React.useState<
+  const [name, setName] = useState("");
+  const [allowedOrigins, setAllowedOrigins] = useState("");
+  const [status, setStatus] = useState<
     false | "requesting" | "success" | "failure"
   >(false);
-  const [message, setMessage] = React.useState("");
-  const [prevIndex] = React.useState(props.selectedTeamIndex);
+  const [message, setMessage] = useState("");
+  const [prevIndex] = useState(props.selectedTeamIndex);
 
   // move on team change
-  React.useEffect(() => {
+  useEffect(() => {
     if (prevIndex !== props.selectedTeamIndex) {
       props.history.push("/api-keys");
     }
@@ -75,7 +75,7 @@ const Content = (props: Props) => {
   const propOrigins = (props.mapKey || { allowedOrigins: [] }).allowedOrigins;
 
   // effects
-  React.useEffect(() => {
+  useEffect(() => {
     setName(propName);
     setAllowedOrigins(propOrigins.join("\n"));
 

--- a/src/components/Maps/APIKeys.tsx
+++ b/src/components/Maps/APIKeys.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Table from "../custom/Table";
 import AddNew from "../custom/AddNew";
@@ -28,7 +28,7 @@ type DispatchProps = {
 type Props = OwnProps & StateProps & DispatchProps;
 
 function Content(props: Props) {
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   const breadcrumbItems = [
     {

--- a/src/components/Paperbase.tsx
+++ b/src/components/Paperbase.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import { withStyles, createStyles } from "@material-ui/core/styles";
 import { ThemeProvider } from "@material-ui/styles";
@@ -87,7 +87,7 @@ export const Paperbase: React.FC<Props> = (props: Props) => {
 
   const isLoggedIn = isReady && !!session;
 
-  const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
 

--- a/src/components/ResetPassword.tsx
+++ b/src/components/ResetPassword.tsx
@@ -1,6 +1,6 @@
 import "./ResetPassword.scss";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 import Support from "./custom/Support";
 import Logo from "./custom/logo.svg";
@@ -26,14 +26,14 @@ const Content = () => {
   const parsed = queryString.parse(window.location.search);
   const qsusername = parsed.username as string;
 
-  const [code, setCode] = React.useState("");
-  const [username, setUsername] = React.useState(qsusername || "");
-  const [password, setPassword] = React.useState("");
-  const [passwordAgain, setPasswordAgain] = React.useState("");
-  const [status, setStatus] = React.useState<
+  const [code, setCode] = useState("");
+  const [username, setUsername] = useState(qsusername || "");
+  const [password, setPassword] = useState("");
+  const [passwordAgain, setPasswordAgain] = useState("");
+  const [status, setStatus] = useState<
     null | "requesting" | "success" | "warning"
   >(null);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   const onCodeChange = (e: React.FormEvent<HTMLInputElement>) => {
     setStatus(null);

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -1,6 +1,6 @@
 import "./Signin.scss";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 import Link from "@material-ui/core/Link";
 import Logo from "./custom/logo.svg";
@@ -42,19 +42,19 @@ type Props = OwnProps & RouterProps & StateProps & DispatchProps;
 const Signin = (props: Props) => {
   const { serverTrouble } = props;
 
-  const [username, setUsername] = React.useState("");
-  const [password, setPassword] = React.useState("");
-  const [status, setStatus] = React.useState<
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<
     null | "requesting" | "success" | "warning"
   >(null);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   const parsed = queryString.parse(window.location.search);
   const hasQueryStringUsername =
     !!parsed.username && typeof parsed.username === "string";
   const hasPasswordReset = parsed.reset === "true";
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (hasQueryStringUsername && username === "") {
       setUsername(parsed.username as string);
       const passwordInput = document.getElementById("password");

--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 
 import Support from "./custom/Support";
@@ -35,11 +35,11 @@ type Props = OwnProps & RouterProps & StateProps & DispatchProps;
 type Status = null | "requesting" | "success" | "warning";
 
 const Signup = (props: Props) => {
-  const [username, setUsername] = React.useState("");
-  const [email, setEmail] = React.useState("");
-  const [password, setPassword] = React.useState("");
-  const [status, setStatus] = React.useState<Status>(null);
-  const [message, setMessage] = React.useState("");
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<Status>(null);
+  const [message, setMessage] = useState("");
 
   const onUsernameChange = (e: React.FormEvent<HTMLInputElement>) => {
     setStatus(null);
@@ -89,7 +89,7 @@ const Signup = (props: Props) => {
   };
 
   // URL locale will be sent to UserPool. So serialize persisted locale at first
-  React.useEffect(() => {
+  useEffect(() => {
     const parsed = queryString.parse(window.location.search);
     parsed.lang = estimateLanguage();
     const newUrl = `/?${queryString.stringify(parsed)}#/signup`;

--- a/src/components/Team/Billing/payment-method-modal.tsx
+++ b/src/components/Team/Billing/payment-method-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Modal from "@material-ui/core/Modal";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
@@ -36,8 +36,8 @@ const { REACT_APP_STAGE } = process.env;
 
 const PaymentMethodModal: React.FC<Props> = (props) => {
   const { open, handleClose, session, teamId } = props;
-  const [loading, setLoading] = React.useState(false);
-  const [message, setMessage] = React.useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
   const stripe = useStripe();
   const elements = useElements();
 

--- a/src/components/Team/general/avatar.tsx
+++ b/src/components/Team/general/avatar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useRef } from "react";
 
 // Components
 import Typography from "@material-ui/core/Typography";
@@ -41,16 +41,16 @@ const ProfileImageStyle: React.CSSProperties = {
 
 const Content = (props: Props) => {
   // states
-  const [status, setStatus] = React.useState<
+  const [status, setStatus] = useState<
     false | "requesting" | "success" | "failure"
   >(false);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   // props
   const { team } = props;
 
   // refs
-  const refContainer = React.useRef<HTMLInputElement | null>(null);
+  const refContainer = useRef<HTMLInputElement | null>(null);
 
   const onFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {

--- a/src/components/Team/general/delete.tsx
+++ b/src/components/Team/general/delete.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 // Components
 import Typography from "@material-ui/core/Typography";
@@ -39,9 +39,9 @@ type Props = OwnProps & StateProps;
 
 const Content = (props: Props) => {
   // state
-  const [open, setOpen] = React.useState(false);
-  const [confirmation, setConfirmation] = React.useState("");
-  const [status, setStatus] = React.useState<
+  const [open, setOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [status, setStatus] = useState<
     false | "requesting" | "success" | "failure"
   >(false);
 

--- a/src/components/Team/general/fields.tsx
+++ b/src/components/Team/general/fields.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 // Components
 import TextField from "@material-ui/core/TextField";
@@ -39,7 +39,7 @@ const Content = (props: Props) => {
   const { session, team, members, selectedIndex, updateTeamState } = props;
   const { teamId, name, description, url, billingEmail } = team;
   // state
-  const [draft, setDraft] = React.useState<Partial<Geolonia.Team>>({});
+  const [draft, setDraft] = useState<Partial<Geolonia.Team>>({});
 
   const onNameBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const name = e.currentTarget.value;
@@ -48,7 +48,7 @@ const Content = (props: Props) => {
 
   // effects
   //// clear draft on Team change
-  React.useEffect(() => setDraft({}), [selectedIndex]);
+  useEffect(() => setDraft({}), [selectedIndex]);
 
   const onSaveClick = () => {
     // update server side

--- a/src/components/Team/members/change-role.tsx
+++ b/src/components/Team/members/change-role.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -50,15 +50,15 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 const ChangeRole = (props: Props) => {
   const { currentMember, open, toggle, updateMemberRoleState } = props;
-  const [role, setRole] = React.useState<false | Geolonia.Role>(
+  const [role, setRole] = useState<false | Geolonia.Role>(
     currentMember.role
   );
-  const [status, setStatus] = React.useState<
+  const [status, setStatus] = useState<
     false | "requesting" | "success" | "failure"
   >(false);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
-  React.useEffect(() => {
+  useEffect(() => {
     setRole(currentMember.role);
   }, [currentMember]);
 

--- a/src/components/Team/members/index.tsx
+++ b/src/components/Team/members/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 // Components
 import Button from "@material-ui/core/Button";
@@ -44,16 +44,16 @@ type Props = OwnProps & StateProps;
 
 const Content = (props: Props) => {
   const { members } = props;
-  const [currentMember, setCurrentMember] = React.useState<
+  const [currentMember, setCurrentMember] = useState<
     false | Geolonia.Member
   >(false);
 
   // Dialogs open
-  const [openChangeRole, setOpenChangeRole] = React.useState(false);
-  const [openSuspend, setOpenSuspend] = React.useState(false);
-  const [openRemoveMember, setOpenRemoveMember] = React.useState(false);
+  const [openChangeRole, setOpenChangeRole] = useState(false);
+  const [openSuspend, setOpenSuspend] = useState(false);
+  const [openRemoveMember, setOpenRemoveMember] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     handleClose();
   }, [openChangeRole, openRemoveMember]);
   const rows: Row[] = members.map(member => {
@@ -101,7 +101,7 @@ const Content = (props: Props) => {
 
   const onClick = (e: any) => {};
 
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     const index = parseInt(event.currentTarget.value);

--- a/src/components/Team/members/invite.tsx
+++ b/src/components/Team/members/invite.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 // Components
 import AddNew from "../../custom/AddNew";
@@ -26,8 +26,8 @@ type StateProps = {
 type Props = OwnProps & StateProps;
 
 export const Invite = (props: Props) => {
-  const [message, setMessage] = React.useState("");
-  const [status, setStatus] = React.useState<
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<
     false | "requesting" | "success" | "failure"
   >(false);
 

--- a/src/components/Team/members/remove-member.tsx
+++ b/src/components/Team/members/remove-member.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -36,10 +36,10 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 const RemoveMember = (props: Props) => {
   const { currentMember, teamName, open, toggle, deleteMemberState } = props;
-  const [status, setStatus] = React.useState<
+  const [status, setStatus] = useState<
     false | "requesting" | "success" | "failure"
   >(false);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   const onRemoveClick = () => {
     setStatus("requesting");

--- a/src/components/Team/members/suspend.tsx
+++ b/src/components/Team/members/suspend.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -45,15 +45,15 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 const Suspend = (props: Props) => {
   const { currentMember, open, toggle, updateMemberRoleState } = props;
-  const [role, setRole] = React.useState<false | Geolonia.Role>(
+  const [role, setRole] = useState<false | Geolonia.Role>(
     currentMember.role
   );
-  const [status, setStatus] = React.useState<
+  const [status, setStatus] = useState<
     false | "requesting" | "success" | "failure"
   >(false);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
-  React.useEffect(() => {
+  useEffect(() => {
     setRole(currentMember.role);
   }, [currentMember]);
 

--- a/src/components/custom/Delete.tsx
+++ b/src/components/custom/Delete.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 // Components
 import Typography from "@material-ui/core/Typography";
@@ -38,9 +38,9 @@ export const Delete: React.FC<Props> = (props) => {
   const { disableCancel, disableDelete } = props;
   const { text1, text2 } = getTexts(props);
 
-  const [open, setOpen] = React.useState(false);
-  const [confirmation, setConfirmation] = React.useState("");
-  const [status, setStatus] = React.useState<Status>(false);
+  const [open, setOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [status, setStatus] = useState<Status>(false);
 
   const isCancelDisabled =
     typeof disableCancel === "function"

--- a/src/components/custom/Save.tsx
+++ b/src/components/custom/Save.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
@@ -33,8 +33,8 @@ const getDefaultProps = (props: Props) => ({
 const Save = (props: Props) => {
   const { label, style, onClick, onError, disabled } = getDefaultProps(props);
 
-  const [open, setOpen] = React.useState(false);
-  const [status, setStatus] = React.useState<
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<
     false | "working" | "success" | "failure"
   >(false);
 

--- a/src/components/custom/Table.tsx
+++ b/src/components/custom/Table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -86,8 +86,8 @@ const TablePaginationActions = (props: TablePaginationActionsProps) => {
 export const CustomTable = (props: Props) => {
   const { rows, rowsPerPage: rowsPerPageDefault = 5, permalink } = props;
 
-  const [offset, setOffset] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(rowsPerPageDefault);
+  const [offset, setOffset] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(rowsPerPageDefault);
 
   const currentRows = rows.slice(offset, offset + rowsPerPage);
   const page = Math.floor(offset / rowsPerPage);

--- a/src/components/resend-code.tsx
+++ b/src/components/resend-code.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 
 import Support from "./custom/Support";
@@ -18,11 +18,11 @@ const ResendCode = () => {
   const parsed = queryString.parse(window.location.search);
   const qsusername = parsed.username as string;
 
-  const [username, setUsername] = React.useState(qsusername || "");
-  const [status, setStatus] = React.useState<
+  const [username, setUsername] = useState(qsusername || "");
+  const [status, setStatus] = useState<
     null | "requesting" | "success" | "warning"
   >(null);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   const onUsernameChange = (e: React.FormEvent<HTMLInputElement>) => {
     setStatus(null);

--- a/src/components/route-controller.tsx
+++ b/src/components/route-controller.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 type Props = {
   isLoggedIn: boolean;
@@ -21,7 +21,7 @@ export const RouteController = (props: Props) => {
     }
   } = props;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       !isLoggedIn &&
       pathname !== "/signup" &&
@@ -35,7 +35,7 @@ export const RouteController = (props: Props) => {
     }
   }, [isLoggedIn, pathname, replace]);
 
-  return <></>;
+  return null;
 };
 
 export default RouteController;

--- a/src/components/verify.tsx
+++ b/src/components/verify.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Button from "@material-ui/core/Button";
 
 import Support from "./custom/Support";
@@ -17,18 +17,18 @@ import { parseVerifyError as parseCognitoVerifyError } from "../lib/cognito/pars
 import { Link } from "@material-ui/core";
 
 const Content = () => {
-  const [username, setUsername] = React.useState("");
-  const [code, setCode] = React.useState("");
-  const [status, setStatus] = React.useState<
+  const [username, setUsername] = useState("");
+  const [code, setCode] = useState("");
+  const [status, setStatus] = useState<
     null | "requesting" | "success" | "warning"
   >(null);
-  const [message, setMessage] = React.useState("");
+  const [message, setMessage] = useState("");
 
   const parsed = queryString.parse(window.location.search);
   const hasQueryStringUsername =
     !!parsed.username && typeof parsed.username === "string";
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (hasQueryStringUsername && username === "") {
       setUsername(parsed.username as string);
       const codeInput = document.getElementById("code");


### PR DESCRIPTION
API キーのページとかと同じように、ページ中でチームを変更した時に強制的に一覧ページに遷移するようにしました。