### PR TITLE
UIのレイアウトを変更

### DIFF
--- a/src/components/Data/GeoJson.tsx
+++ b/src/components/Data/GeoJson.tsx
@@ -199,7 +199,7 @@ const Content = (props: Props) => {
         title={geoJsonMeta ? geoJsonMeta.name : ""}
       >
         {__(
-          "You can manage and style features in your GeoJSON, and get the the access point URL of GeoJSON API."
+          "You can upload your location data. Also you can get embed HTML code to add the map to your web site."
         )}
       </Title>
 

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -267,6 +267,20 @@ const GeoJSONMeta = (props: Props) => {
     <Grid className="geojson-meta" container spacing={2}>
       <Grid item sm={4} xs={12}>
         <Paper className="geojson-title-description">
+          <h3>{__("Name")}</h3>
+          <input
+            type="text"
+            value={draftName}
+            onChange={e => setDraftName(e.currentTarget.value)}
+          />
+
+          <Save
+            onClick={() => saveHandler(draftName)}
+            disabled={draftName === name}
+          />
+          <p>{__("Name of public GeoJSON will be displayed in public.")}</p>
+        </Paper>
+        <Paper className="geojson-title-description">
           <div>
             <Switch
               checked={draftIsPublic}
@@ -337,21 +351,54 @@ const GeoJSONMeta = (props: Props) => {
             </p> */}
           </div>
         </Paper>
-
-        <Paper className="geojson-title-description">
-          <h3>{__("Name")}</h3>
-          <input
-            type="text"
-            value={draftName}
-            onChange={e => setDraftName(e.currentTarget.value)}
-          />
-
-          <Save
-            onClick={() => saveHandler(draftName)}
-            disabled={draftName === name}
-          />
-          <p>{__("Name of public GeoJSON will be displayed in public.")}</p>
-        </Paper>
+        {draftIsPublic && (
+          <Paper className="geojson-title-description">
+            <h3>{__("Access allowed URLs")}</h3>
+            <p>{__("Please enter a URL to allow access to the map. To specify multiple URLs, insert a new line after each URL.")}</p>
+            <TextField
+              id="standard-name"
+              label={__("URLs")}
+              margin="normal"
+              multiline={true}
+              rows={5}
+              placeholder="https://example.com"
+              fullWidth={true}
+              value={draftAllowedOrigins}
+              onChange={e => setDraftAllowedOrigins(e.target.value)}
+              disabled={saveStatus === "requesting"}
+            />
+            <Help>
+              <Typography component="p">
+                {__(
+                  "Only requests that come from the URLs specified here will be allowed."
+                )}
+              </Typography>
+              <ul>
+                <li>
+                  {__("Any page in a specific URL:")}{" "}
+                  <strong>https://www.example.com</strong>
+                </li>
+                <li>
+                  {__("Any subdomain:")} <strong>https://*.example.com</strong>
+                </li>
+                <li>
+                  {__("A URL with a non-standard port:")}{" "}
+                  <strong>https://example.com:*</strong>
+                </li>
+              </ul>
+              <p>
+                {__(
+                  'Note: Wild card (*) will be matched to a-z, A-Z, 0-9, "-", "_".'
+                )}
+              </p>
+            </Help>
+            <Save
+              onClick={onUpdateClick}
+              onError={onRequestError}
+              disabled={saveDisabled}
+            />
+          </Paper>
+        )}
       </Grid>
       <Grid item sm={8} xs={12}>
         <Paper style={sidebarStyle}>
@@ -430,54 +477,6 @@ const GeoJSONMeta = (props: Props) => {
             </Button>
           </p>
         </Paper>
-        {draftIsPublic && (
-          <Paper className="geojson-title-description">
-            <h3>{__("Access allowed URLs")}</h3>
-            <p>{__("Please enter a URL to allow access to the map. To specify multiple URLs, insert a new line after each URL.")}</p>
-            <TextField
-              id="standard-name"
-              label={__("URLs")}
-              margin="normal"
-              multiline={true}
-              rows={5}
-              placeholder="https://example.com"
-              fullWidth={true}
-              value={draftAllowedOrigins}
-              onChange={e => setDraftAllowedOrigins(e.target.value)}
-              disabled={saveStatus === "requesting"}
-            />
-            <Help>
-              <Typography component="p">
-                {__(
-                  "Only requests that come from the URLs specified here will be allowed."
-                )}
-              </Typography>
-              <ul>
-                <li>
-                  {__("Any page in a specific URL:")}{" "}
-                  <strong>https://www.example.com</strong>
-                </li>
-                <li>
-                  {__("Any subdomain:")} <strong>https://*.example.com</strong>
-                </li>
-                <li>
-                  {__("A URL with a non-standard port:")}{" "}
-                  <strong>https://example.com:*</strong>
-                </li>
-              </ul>
-              <p>
-                {__(
-                  'Note: Wild card (*) will be matched to a-z, A-Z, 0-9, "-", "_".'
-                )}
-              </p>
-            </Help>
-            <Save
-              onClick={onUpdateClick}
-              onError={onRequestError}
-              disabled={saveDisabled}
-            />
-          </Paper>
-        )}
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
Closes #388 

変更内容

- 名前、地図ステータス（public/private ・draft/published）、AllowedOrigins の順番に変更（情報のレイヤーとしては名前が優先だと思ったので上に移動しました。どうでしょうか？）
- タイトル下の説明をベクトルタイルの変更に合わせて修正。

### UI のレイアウトを変更

![スクリーンショット 2021-07-16 15 31 17](https://user-images.githubusercontent.com/8760841/125902738-5d0a5bc0-e802-42a1-ba06-092ba5c2b407.png)


### タイトル下の説明を変更

![スクリーンショット 2021-07-16 15 33 57](https://user-images.githubusercontent.com/8760841/125902976-ee6d517c-7a62-4bdd-ab79-b51b16a8a6aa.png)
