### PR TITLE
ウェルカムカードの文章を目的別に変更

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -53,19 +53,25 @@ const Dashboard = (props: Props) => {
     <div id="dashboard">
       <Paper className="getting-started">
         <div className="box-content">
-          <h2>{sprintf(__("Welcome, %s"), displayName)}</h2>
+          <h2>{__("Get started with Geolonia map")}</h2>
           <ul>
             <li>
               <Link href="#/api-keys" color="inherit" underline="always">
-                {__("Get API key")}
+                {__("Display a map")}
               </Link>{" "}
-              - {__("Get API key then create your map!")}
+              - {__("Get API key then add the map to your web site")}
             </li>
             <li>
               <Link href="#/data/geojson" color="inherit" underline="always">
-                {__("GeoJSON API")}
+                {__("Upload your data")}
               </Link>{" "}
-              - {__("Manage and style your GeoJSON.")}
+              - {__("Upload CSV or GeoJSON to display in your map")}
+            </li>
+            <li>
+              <Link href="https://docs.geolonia.com/" color="inherit" underline="always" target="_blank" rel="noopener noreferrer">
+                {__("Build a custom map")}
+              </Link>{" "}
+              - {__("Browse developer docs")}
             </li>
           </ul>
         </div>

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -189,7 +189,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
       icon: <DescriptionOutlinedIcon />,
       children: [
         {
-          id: __("Official Documents"),
+          id: __("Developer Documents"),
           icon: <DescriptionIcon />,
           href: "https://docs.geolonia.com/",
           active: false


### PR DESCRIPTION
Closes #419 

ウェルカムカード？の文章を目的別に変更しました。開発者ドキュメントへのリンクも追加したのですがどうでしょうか？

<img width="541" alt="スクリーンショット 2021-07-26 15 23 00" src="https://user-images.githubusercontent.com/8760841/126942407-8736cf26-217e-4832-b62a-22731d91232d.png">

それと、サイドバーのドキュメントへのリンク名の「公式ドキュメント」をより、具体的な「開発者ドキュメント」に変更しました。

<img width="156" alt="スクリーンショット 2021-07-26 15 23 07" src="https://user-images.githubusercontent.com/8760841/126942422-81354b11-7a91-4862-adf9-f44e00705f3d.png">
