### PR TITLE
サイドバーの「公式ドキュメント」に target="_blank" を追加

### DIFF
--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -128,18 +128,24 @@ const Navigator: React.FC<Props> = (props: Props) => {
 
   const selectedTeam: Geolonia.Team | undefined = teams[selectedTeamIndex];
 
+  const navigatorDefault = {
+    active: false,
+    target: "_self",
+    rel: "",
+  }
+
   const teamSettingsChildren = [
     {
       id: __("General"),
       icon: <ViewListIcon />,
       href: "#/team/general",
-      active: false
+      ...navigatorDefault
     },
     {
       id: __("Members"),
       icon: <GroupIcon />,
       href: "#/team/members",
-      active: false
+      ...navigatorDefault
     },
   ];
 
@@ -148,7 +154,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
       id: __("Billing"),
       icon: <PaymentIcon />,
       href: "#/team/billing",
-      active: false,
+      ...navigatorDefault
     });
   }
 
@@ -161,7 +167,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
           id: __("Manage API keys"),
           icon: <CodeIcon />,
           href: "#/api-keys",
-          active: false
+          ...navigatorDefault
         }
         // { id: 'Styles', icon: <SatelliteIcon />, href: "#/maps/styles", active: false },
       ]
@@ -174,7 +180,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
           id: __("GeoJSON API"),
           icon: <RoomIcon />,
           href: "#/data/geojson",
-          active: false
+          ...navigatorDefault
         }
         // { id: 'Geolonia Live Locations', icon: <MyLocationIcon />, href: "#/data/features", active: false },
       ]
@@ -192,7 +198,9 @@ const Navigator: React.FC<Props> = (props: Props) => {
           id: __("Official Documents"),
           icon: <DescriptionIcon />,
           href: "https://docs.geolonia.com/",
-          active: false
+          active: false,
+          target: "_blank",
+          rel: "noopener noreferrer",
         }
       ]
     }
@@ -287,11 +295,13 @@ const Navigator: React.FC<Props> = (props: Props) => {
                 {id}
               </ListItemText>
             </ListItem>
-            {children.map(({ id: childId, active, href }) => (
+            {children.map(({ id: childId, active, href, target, rel }) => (
               <ListItem
                 button
                 component="a"
                 href={href}
+                target={target}
+                rel={rel}
                 key={childId}
                 className={`categoryItemcontent ${clsx(classes.item, active && classes.itemActiveItem)}`}
               >

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useState } from "react";
+import React, { useState } from "react";
 import clsx from "clsx";
 import { withStyles, Theme } from "@material-ui/core/styles";
 import Divider from "@material-ui/core/Divider";
@@ -142,13 +142,13 @@ const Navigator: React.FC<Props> = (props: Props) => {
       id: __("General"),
       icon: <ViewListIcon />,
       href: "#/team/general",
-      active: false,
+      active: false
     },
     {
       id: __("Members"),
       icon: <GroupIcon />,
       href: "#/team/members",
-      active: false,
+      active: false
     },
   ];
 
@@ -157,7 +157,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
       id: __("Billing"),
       icon: <PaymentIcon />,
       href: "#/team/billing",
-      active: false,
+      active: false
     });
   }
 
@@ -170,7 +170,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
           id: __("Manage API keys"),
           icon: <CodeIcon />,
           href: "#/api-keys",
-          active: false,
+          active: false
         }
         // { id: 'Styles', icon: <SatelliteIcon />, href: "#/maps/styles", active: false },
       ]
@@ -183,7 +183,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
           id: __("GeoJSON API"),
           icon: <RoomIcon />,
           href: "#/data/geojson",
-          active: false,
+          active: false
         }
         // { id: 'Geolonia Live Locations', icon: <MyLocationIcon />, href: "#/data/features", active: false },
       ]

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { Component, useState } from "react";
 import clsx from "clsx";
 import { withStyles, Theme } from "@material-ui/core/styles";
 import Divider from "@material-ui/core/Divider";
@@ -109,6 +109,15 @@ type DispatchProps = {
 
 type Props = OwnProps & StateProps & DispatchProps;
 
+interface TeamSettingChild {
+  id: string;
+  icon: JSX.Element;
+  href: string;
+  active: boolean;
+  target?: string;
+  rel?: string;
+}
+
 const Navigator: React.FC<Props> = (props: Props) => {
   const initialValueForNewTeamName = __("My team");
 
@@ -128,24 +137,18 @@ const Navigator: React.FC<Props> = (props: Props) => {
 
   const selectedTeam: Geolonia.Team | undefined = teams[selectedTeamIndex];
 
-  const navigatorDefault = {
-    active: false,
-    target: "_self",
-    rel: "",
-  }
-
-  const teamSettingsChildren = [
+  const teamSettingsChildren: TeamSettingChild[] = [
     {
       id: __("General"),
       icon: <ViewListIcon />,
       href: "#/team/general",
-      ...navigatorDefault
+      active: false,
     },
     {
       id: __("Members"),
       icon: <GroupIcon />,
       href: "#/team/members",
-      ...navigatorDefault
+      active: false,
     },
   ];
 
@@ -154,7 +157,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
       id: __("Billing"),
       icon: <PaymentIcon />,
       href: "#/team/billing",
-      ...navigatorDefault
+      active: false,
     });
   }
 
@@ -167,7 +170,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
           id: __("Manage API keys"),
           icon: <CodeIcon />,
           href: "#/api-keys",
-          ...navigatorDefault
+          active: false,
         }
         // { id: 'Styles', icon: <SatelliteIcon />, href: "#/maps/styles", active: false },
       ]
@@ -180,7 +183,7 @@ const Navigator: React.FC<Props> = (props: Props) => {
           id: __("GeoJSON API"),
           icon: <RoomIcon />,
           href: "#/data/geojson",
-          ...navigatorDefault
+          active: false,
         }
         // { id: 'Geolonia Live Locations', icon: <MyLocationIcon />, href: "#/data/features", active: false },
       ]


### PR DESCRIPTION
Closes #412 

サイドバーの「公式ドキュメント」に target="_blank" を追加しました。

気になる点

target="_blank" 以外の rel 属性が空になり rel となってしまうので、もし他に何か良い方法があれば教えて頂けると…！

<img width="953" alt="スクリーンショット 2021-07-26 15 50 05" src="https://user-images.githubusercontent.com/8760841/126945423-5a8d1401-cb2f-494e-af11-ffaa5a128970.png">
