### PR TITLE
Fix user avatar crop

### DIFF
--- a/src/components/User/avatar.tsx
+++ b/src/components/User/avatar.tsx
@@ -37,11 +37,10 @@ type State = {
 };
 
 const ProfileImageStyle: React.CSSProperties = {
-  width: "100%",
-  maxWidth: "250px",
-  height: "auto",
+  width: "250px",
+  height: "250px",
   fill: "#dedede",
-  margin: "auto"
+  margin: "auto",
 };
 
 export class AvatarSection extends React.Component<Props, State> {


### PR DESCRIPTION
左上のアイコンに合わせて1:1 で画像中央を表示するようにしました。

<img width="593" alt="スクリーンショット 2021-07-30 10 51 05" src="https://user-images.githubusercontent.com/6292312/127587962-f7f6218e-baba-4060-8d1c-8f78a6511e65.png">
