### PR TITLE
get-geolonia の不要なリンクを非表示に

### DIFF
--- a/src/components/Data/GeoJsonMeta.scss
+++ b/src/components/Data/GeoJsonMeta.scss
@@ -1,3 +1,5 @@
+// get-geolonia の不要なリンクを消す
+// Fix: https://github.com/geolonia/get-geolonia/issues/24
 #geolonia-map-outer-container
 {
   div.code-container

--- a/src/components/Data/GeoJsonMeta.scss
+++ b/src/components/Data/GeoJsonMeta.scss
@@ -1,0 +1,9 @@
+#geolonia-map-outer-container
+{
+  div.code-container
+  {
+    a {
+      display: none;
+    }
+  }
+}

--- a/src/components/Data/GeoJsonMeta.tsx
+++ b/src/components/Data/GeoJsonMeta.tsx
@@ -28,6 +28,7 @@ import normalizeOrigin from "../../lib/normalize-origin";
 import { buildApiUrl } from "../../lib/api";
 import { GeoJsonMetaSetter } from "./GeoJson/hooks/use-geojson";
 import Interweave from "interweave";
+import "./GeoJsonMeta.scss";
 
 const { REACT_APP_STAGE, REACT_APP_TILE_SERVER } = process.env;
 


### PR DESCRIPTION
Closes https://github.com/geolonia/get-geolonia/issues/24

get-geolonia が「Do you have an API key ?」というリンクを追加していたので非表示に。

get-geolonia の方で対応しようかとしたのですが、app.geolonia.com に固有の問題だったのでこちらで修正しました。

![スクリーンショット 2021-07-30 12 08 47](https://user-images.githubusercontent.com/8760841/127594119-a2e1402a-8165-4d15-a11a-48a4e791e5e2.png)
