### PR TITLE
Geolonia ロゴの削除

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -143,21 +143,6 @@ const Header = (props: Props) => {
                 <MenuItem onClick={handleSignout}>{__("Logout")}</MenuItem>
               </Menu>
             </Grid>
-
-
-
-            <Grid item>
-              <IconButton
-                className="iconButtonlogo"
-                href="https://geolonia.com/"
-                target="_blank"
-              >
-                <img src={Logo} alt="" className="logo" />
-              </IconButton>
-            </Grid>
-
-
-
           </Grid>
         </Toolbar>
       </AppBar>


### PR DESCRIPTION
Closes #430 

右上のロゴをクリック時に外部へ飛ぶとユーザーに違和感を与えそう。（FacebookのロゴをクリックするとFacebookのコーポレートサイトに飛ぶような）なので削除しました。

今後、Geolonia ロゴを押すとホームへ戻る仕様のロゴを追加するのは良さそうです。


<img width="136" alt="127583201-0fe0d251-8c50-4994-b672-afed8a1590fa" src="https://user-images.githubusercontent.com/8760841/127759770-ecfcae85-317a-4d75-b65a-6d7ee3c05d6c.png">
