### PR TITLE
トップページに「Create Map」ボタンを追加

### DIFF
--- a/src/components/Dashboard.scss
+++ b/src/components/Dashboard.scss
@@ -54,7 +54,7 @@
     margin-bottom: 1em;
     border: none !important;
     box-shadow: none !important;
-    padding: 30px;
+    padding: 40px 35px;
     border: 6px solid #fff !important;
 
     .box-icon
@@ -75,9 +75,12 @@
     {
       h2
       {
-        margin: 0;
-        font-weight: normal;
+        margin: 10px 0;
+        font-weight: 900;
         letter-spacing: 0.04em;
+        color: #333333;
+        line-height: 32px;
+        font-size: 30px;
       }
 
       ul

--- a/src/components/Dashboard.scss
+++ b/src/components/Dashboard.scss
@@ -54,7 +54,7 @@
     margin-bottom: 1em;
     border: none !important;
     box-shadow: none !important;
-    padding: 40px 35px;
+    padding: 35px;
     border: 6px solid #fff !important;
 
     .box-icon

--- a/src/components/Dashboard.scss
+++ b/src/components/Dashboard.scss
@@ -95,4 +95,9 @@
       }
     }
   }
+  .create-new
+  {
+    background-color: #039A4A;
+    color: #fff;
+  }
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import Paper from "@material-ui/core/Paper";
 import { withStyles, Theme } from "@material-ui/core/styles";
 import Link from "@material-ui/core/Link";
+import Button from "@material-ui/core/Button";
+
 import Hidden from "@material-ui/core/Hidden";
 import { sprintf, __ } from "@wordpress/i18n";
 import moment from "moment";
@@ -55,7 +57,7 @@ const Dashboard = (props: Props) => {
       <Paper className="getting-started">
         <div className="box-content">
           <h2>{__("Get started with Geolonia map")}</h2>
-          <ul>
+          {/* <ul>
             <li>
               <Link href="#/api-keys" color="inherit" underline="always">
                 {__("Display a map")}
@@ -74,7 +76,9 @@ const Dashboard = (props: Props) => {
               </Link>{" "}
               - {__("Browse developer docs")}
             </li>
-          </ul>
+          </ul> */}
+          <p>まずAPI キーを取得し、地図のデザインや表示位置の初期設定をしてください。<br/> そのあと生成された HTML コードスニペットをあなたの Webサイトに追加すると、作成した地図が表示されます。</p>
+          <Button className="create-new" variant="contained" size="large">{__("地図を作成する")}</Button>
         </div>
       </Paper>
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -53,8 +53,8 @@ const Dashboard = (props: Props) => {
       <Paper className="getting-started">
         <div className="box-content">
           <h2>{__("Get started with Geolonia map")}</h2>
-          <p>まずAPI キーを取得し、地図のデザインや表示位置の初期設定をしてください。<br/> そのあと生成された HTML コードスニペットをあなたの Webサイトに追加すると、作成した地図が表示されます。</p>
-          <Button className="create-new" variant="contained" size="large" onClick={() => window.location.href = '/#/api-keys'}>{__("地図を作成する")}</Button>
+          <p>{__("First, you need to obtain an API key and set up the initial settings for the map design and display position.")}<br/>{__("After that, add the generated HTML code snippet to your website to display the map you have created.")}</p>
+          <Button className="create-new" variant="contained" size="large" onClick={() => window.location.href = '/#/api-keys'}>{__("Create map")}</Button>
         </div>
       </Paper>
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@ import iconPlane from "./custom/plane.svg";
 import "./Dashboard.scss";
 import { connect } from "react-redux";
 
+import Tutorials from './Turorials'
 import DeveloperBlog from "./DeveloperBlog";
 
 const styles = (theme: Theme) => ({});
@@ -77,8 +78,10 @@ const Dashboard = (props: Props) => {
         </div>
       </Paper>
 
-      <h2 style={{ marginTop: "32px" }}>{__("Developer's Blog")}</h2>
+      <h2 style={{ marginTop: "32px" }}>{__("Tutorials")}</h2>
+      <Tutorials></Tutorials>
 
+      <h2 style={{ marginTop: "32px" }}>{__("Developer's Blog")}</h2>
       <DeveloperBlog />
     </div>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,13 +2,9 @@ import React from "react";
 
 import Paper from "@material-ui/core/Paper";
 import { withStyles, Theme } from "@material-ui/core/styles";
-import Link from "@material-ui/core/Link";
 import Button from "@material-ui/core/Button";
-
-import Hidden from "@material-ui/core/Hidden";
-import { sprintf, __ } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import moment from "moment";
-import iconPlane from "./custom/plane.svg";
 
 import "./Dashboard.scss";
 import { connect } from "react-redux";
@@ -57,28 +53,8 @@ const Dashboard = (props: Props) => {
       <Paper className="getting-started">
         <div className="box-content">
           <h2>{__("Get started with Geolonia map")}</h2>
-          {/* <ul>
-            <li>
-              <Link href="#/api-keys" color="inherit" underline="always">
-                {__("Display a map")}
-              </Link>{" "}
-              - {__("Create API key then add the map to your web site")}
-            </li>
-            <li>
-              <Link href="#/data/geojson" color="inherit" underline="always">
-                {__("Upload your data")}
-              </Link>{" "}
-              - {__("Display CSV or GeoJSON in your map")}
-            </li>
-            <li>
-              <Link href="https://docs.geolonia.com/" color="inherit" underline="always" target="_blank" rel="noopener noreferrer">
-                {__("Build a custom map")}
-              </Link>{" "}
-              - {__("Browse developer docs")}
-            </li>
-          </ul> */}
           <p>まずAPI キーを取得し、地図のデザインや表示位置の初期設定をしてください。<br/> そのあと生成された HTML コードスニペットをあなたの Webサイトに追加すると、作成した地図が表示されます。</p>
-          <Button className="create-new" variant="contained" size="large">{__("地図を作成する")}</Button>
+          <Button className="create-new" variant="contained" size="large" onClick={() => window.location.href = '/#/api-keys'}>{__("地図を作成する")}</Button>
         </div>
       </Paper>
 

--- a/src/components/Maps/APIKeys.scss
+++ b/src/components/Maps/APIKeys.scss
@@ -2,5 +2,5 @@
 {
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }

--- a/src/components/Maps/APIKeys.scss
+++ b/src/components/Maps/APIKeys.scss
@@ -1,0 +1,6 @@
+.tutorial-create-api-key
+{
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+}

--- a/src/components/Maps/APIKeys.tsx
+++ b/src/components/Maps/APIKeys.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Table from "../custom/Table";
 import AddNew from "../custom/AddNew";
 import Title from "../custom/Title";
+import Paper from '@material-ui/core/Paper';
 
 import { __ } from "@wordpress/i18n";
 import { connect } from "react-redux";
@@ -14,6 +15,8 @@ import createKey from "../../api/keys/create";
 import Redux from "redux";
 import { createActions as createMapKeyActions } from "../../redux/actions/map-key";
 import dateParse from "../../lib/date-parse";
+
+import "./APIKeys.scss";
 
 type OwnProps = Record<string, never>;
 type StateProps = {
@@ -64,21 +67,26 @@ function Content(props: Props) {
     };
   });
 
+  const newAPIButton = <AddNew
+    label={__("Create a new API key")}
+    description={__("Please enter the name of new API key.")}
+    defaultValue={__("My API")}
+    onClick={handler}
+    onError={() => void 0}
+    errorMessage={message}
+  />
+
   return (
     <div>
-      <Title breadcrumb={breadcrumbItems} title={__("API keys")}>
-        {mapKeys.length === 0 &&
-          __("You need an API key to display map. Get an API key.")}
-      </Title>
+      <Title breadcrumb={breadcrumbItems} title={__("API keys")}/>
 
-      <AddNew
-        label={__("Create a new API key")}
-        description={__("Please enter the name of new API key.")}
-        defaultValue={__("My API")}
-        onClick={handler}
-        onError={() => void 0}
-        errorMessage={message}
-      />
+      {mapKeys.length === 0 ? <div className={"tutorial-create-api-key"}>
+          <h3>{__("You need an API key to display map. Get an API key.")}</h3>
+          {newAPIButton}
+      </div>
+      :
+        newAPIButton
+      }
 
       <Table rows={rows} rowsPerPage={10} permalink="/api-keys/%s" />
     </div>

--- a/src/components/Turorials.tsx
+++ b/src/components/Turorials.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from 'react'
+import { __ } from '@wordpress/i18n'
+
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+
+const getTutorialContents = () => {
+  return [
+    {
+      title: __('Get Started'),
+      excerpt: __('Learn about the easiest way to embed a Geolonia map in your website.'),
+      url: 'https://docs.geolonia.com/tutorial/'
+    },
+    {
+      title: __('Embed API'),
+      excerpt: __('The Embed API allows you to set up a map with just a simple HTML code.'),
+      url: 'https://docs.geolonia.com/embed-api/'
+    },
+    {
+      title: __('JavaScript API'),
+      excerpt: __('Learn how to develop a professional map application using the JavaScript API.'),
+      url: 'https://docs.geolonia.com/javascript-api/'
+    },
+    {
+      title: __('Custom Style'),
+      excerpt: __('Learn how to customize the style of your map.'),
+      url: 'https://docs.geolonia.com/custom-style/'
+    },
+    {
+      title: __('Support'),
+      excerpt: __('Contact Geolonia'),
+      url: 'https://geolonia.com/'
+    },
+  ]
+}
+
+const useStyles = makeStyles({
+  root: {
+    height: "100%",
+  },
+})
+
+export const Tutorials: React.FC = () => {
+  const turotialContents = useMemo(getTutorialContents, [])
+  const classes = useStyles()
+
+  return <Grid container spacing={2}>
+    {
+      turotialContents.map((post) => <Grid item lg={4} md={6} xs={12} key={post.title}>
+        <Card className={classes.root}>
+          <CardActionArea onClick={() => window.location.href = post.url}>
+            <CardContent>
+            <Typography gutterBottom variant="h5" component="h2">{post.title}</Typography>
+            <Typography variant="body2" color="textSecondary" component="p">{post.excerpt}</Typography>            </CardContent>
+          </CardActionArea>
+        </Card>
+      </Grid>)
+    }
+  </Grid>
+}
+
+export default Tutorials

--- a/src/components/custom/Title.tsx
+++ b/src/components/custom/Title.tsx
@@ -13,7 +13,7 @@ type breadcrumbItems = {
 
 type Props = {
   title: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   breadcrumb: Array<breadcrumbItems>;
 };
 

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -10,14 +10,13 @@
       "Your invitation has been validated.": ["招待が有効化されました。"],
       "Your invitation has been outdated.": ["この招待は無効です。"],
       "Get started with Geolonia map": ["Geoloniaの地図を使ってみる"],
-      "Display a map": ["地図の表示"],
-      "Create API key then add the map to your web site": [
-        "API キーを作成してWebサイトに地図を追加"
+      "First, you need to obtain an API key and set up the initial settings for the map design and display position.": [
+        "まずAPI キーを取得し、地図のデザインや表示位置の初期設定をしてください。"
       ],
-      "Upload your data": ["データをアップロード"],
-      "Display CSV or GeoJSON in your map": ["CSV / GeoJSON を地図に表示"],
-      "Build a custom map": ["カスタムマップを作成"],
-      "Browse developer docs": ["開発者ドキュメントを参照"],
+      "After that, add the generated HTML code snippet to your website to display the map you have created.": [
+        "そのあと生成された HTML コードスニペットをあなたの Webサイトに追加すると、作成した地図が表示されます。"
+      ],
+      "Create map": ["地図を作成する"],
       "Tutorials": ["チュートリアル"],
       "Developer's Blog": ["Developer's Blog"],
       "Download GeoJSON": ["GeoJSON をダウンロード"],
@@ -178,14 +177,14 @@
       ],
       "Your API Key": ["あなたの API キー"],
       "(No date)": ["(データなし)"],
-      "You need an API key to display map. Get an API key.": [
-        "地図の作成にはAPIキーが必要です。「新規作成」をクリックしてAPIキーを作成してください。"
-      ],
       "Create a new API key": ["新しい API キーを作成"],
       "Please enter the name of new API key.": [
         "新しいAPI キーの名前を入力して保存してください。"
       ],
       "My API": ["API キー"],
+      "You need an API key to display map. Get an API key.": [
+        "地図の作成にはAPIキーが必要です。「新規作成」をクリックしてAPIキーを作成してください。"
+      ],
       "My team": ["My team"],
       "General": ["一般"],
       "Members": ["メンバー"],

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -14,7 +14,7 @@
         "まずAPI キーを取得し、地図のデザインや表示位置の初期設定をしてください。"
       ],
       "After that, add the generated HTML code snippet to your website to display the map you have created.": [
-        "そのあと生成された HTML コードスニペットをあなたの Webサイトに追加すると、作成した地図が表示されます。"
+        "その後、生成された HTML コードスニペットをあなたの Webサイトに追加すると、作成した地図が表示されます。"
       ],
       "Create map": ["地図を作成する"],
       "Tutorials": ["チュートリアル"],

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -18,6 +18,7 @@
       "Display CSV or GeoJSON in your map": ["CSV / GeoJSON を地図に表示"],
       "Build a custom map": ["カスタムマップを作成"],
       "Browse developer docs": ["開発者ドキュメントを参照"],
+      "Tutorials": ["チュートリアル"],
       "Developer's Blog": ["Developer's Blog"],
       "Download GeoJSON": ["GeoJSON をダウンロード"],
       "Map": ["地図"],
@@ -339,6 +340,24 @@
       "The following members will be suspended:": [
         "以下のメンバーによる操作が一時停止されます。"
       ],
+      "Get Started": ["Get Started"],
+      "Learn about the easiest way to embed a Geolonia map in your website.": [
+        "ウェブサイトに Geolonia の地図を埋め込む最も簡単な方法についてご紹介します。"
+      ],
+      "Embed API": ["Embed API"],
+      "The Embed API allows you to set up a map with just a simple HTML code.": [
+        "Embed API を使用すると、簡単な HTML を記述するだけで地図を設置することが可能です。"
+      ],
+      "JavaScript API": ["JavaScript API"],
+      "Learn how to develop a professional map application using the JavaScript API.": [
+        "JavaScript API を使った本格的な地図アプリの開発方法についてご紹介します。"
+      ],
+      "Custom Style": ["カスタムスタイル"],
+      "Learn how to customize the style of your map.": [
+        "地図のスタイルをカスタマイズする方法についてご紹介します。"
+      ],
+      "Support": ["サポート"],
+      "Contact Geolonia": ["お問い合わせ"],
       "Your profile": ["プロフィール"],
       "You can update your profile and security.": [
         "プロフィールとセキュリティを設定できます。"
@@ -370,7 +389,6 @@
       "Failed to save.": ["保存できませんでした。"],
       "Terms": ["利用規約"],
       "Privacy": ["プライバシー"],
-      "Contact Geolonia": ["お問い合わせ"],
       "Coming soon": ["準備中"],
       "Japanese": ["日本語"],
       "English": ["英語"],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -22,39 +22,34 @@ msgstr "招待が有効化されました。"
 msgid "Your invitation has been outdated."
 msgstr "この招待は無効です。"
 
-#: src/components/Dashboard.tsx:57
+#: src/components/Dashboard.tsx:55
 msgid "Get started with Geolonia map"
 msgstr "Geoloniaの地図を使ってみる"
 
+#: src/components/Dashboard.tsx:56
+msgid ""
+"First, you need to obtain an API key and set up the initial settings for the "
+"map design and display position."
+msgstr ""
+"まずAPI キーを取得し、地図のデザインや表示位置の初期設定をしてください。"
+
+#: src/components/Dashboard.tsx:56
+msgid ""
+"After that, add the generated HTML code snippet to your website to display "
+"the map you have created."
+msgstr ""
+"そのあと生成された HTML コードスニペットをあなたの Webサイトに追加すると、作"
+"成した地図が表示されます。"
+
+#: src/components/Dashboard.tsx:57
+msgid "Create map"
+msgstr "地図を作成する"
+
 #: src/components/Dashboard.tsx:61
-msgid "Display a map"
-msgstr "地図の表示"
-
-#: src/components/Dashboard.tsx:63
-msgid "Create API key then add the map to your web site"
-msgstr "API キーを作成してWebサイトに地図を追加"
-
-#: src/components/Dashboard.tsx:67
-msgid "Upload your data"
-msgstr "データをアップロード"
-
-#: src/components/Dashboard.tsx:69
-msgid "Display CSV or GeoJSON in your map"
-msgstr "CSV / GeoJSON を地図に表示"
-
-#: src/components/Dashboard.tsx:73
-msgid "Build a custom map"
-msgstr "カスタムマップを作成"
-
-#: src/components/Dashboard.tsx:75
-msgid "Browse developer docs"
-msgstr "開発者ドキュメントを参照"
-
-#: src/components/Dashboard.tsx:81
 msgid "Tutorials"
 msgstr "チュートリアル"
 
-#: src/components/Dashboard.tsx:84
+#: src/components/Dashboard.tsx:64
 msgid "Developer's Blog"
 msgstr "Developer's Blog"
 
@@ -108,7 +103,7 @@ msgid "Adding your data to the map..."
 msgstr "データを地図に追加しています。"
 
 #: src/components/Data/GeoJson.tsx:99 src/components/Data/GeoJsons.tsx:91
-#: src/components/Maps/APIKey.tsx:114 src/components/Maps/APIKeys.tsx:35
+#: src/components/Maps/APIKey.tsx:114 src/components/Maps/APIKeys.tsx:38
 #: src/components/Navigator.tsx:265 src/components/Team/Billing.tsx:173
 msgid "Home"
 msgstr "ホーム"
@@ -433,7 +428,7 @@ msgstr "プロフィール"
 msgid "Logout"
 msgstr "ログアウト"
 
-#: src/components/Maps/APIKey.tsx:118 src/components/Maps/APIKeys.tsx:69
+#: src/components/Maps/APIKey.tsx:118 src/components/Maps/APIKeys.tsx:81
 #: src/components/Navigator.tsx:153
 msgid "API keys"
 msgstr "API キー"
@@ -480,27 +475,27 @@ msgstr "この API キーを本当に削除しますか？"
 msgid "Your API Key"
 msgstr "あなたの API キー"
 
-#: src/components/Maps/APIKeys.tsx:63
+#: src/components/Maps/APIKeys.tsx:66
 msgid "(No date)"
 msgstr "(データなし)"
 
 #: src/components/Maps/APIKeys.tsx:71
+msgid "Create a new API key"
+msgstr "新しい API キーを作成"
+
+#: src/components/Maps/APIKeys.tsx:72
+msgid "Please enter the name of new API key."
+msgstr "新しいAPI キーの名前を入力して保存してください。"
+
+#: src/components/Maps/APIKeys.tsx:73
+msgid "My API"
+msgstr "API キー"
+
+#: src/components/Maps/APIKeys.tsx:84
 msgid "You need an API key to display map. Get an API key."
 msgstr ""
 "地図の作成にはAPIキーが必要です。「新規作成」をクリックしてAPIキーを作成して"
 "ください。"
-
-#: src/components/Maps/APIKeys.tsx:75
-msgid "Create a new API key"
-msgstr "新しい API キーを作成"
-
-#: src/components/Maps/APIKeys.tsx:76
-msgid "Please enter the name of new API key."
-msgstr "新しいAPI キーの名前を入力して保存してください。"
-
-#: src/components/Maps/APIKeys.tsx:77
-msgid "My API"
-msgstr "API キー"
 
 #: src/components/Navigator.tsx:109
 msgid "My team"
@@ -957,7 +952,8 @@ msgstr "Get Started"
 
 #: src/components/Turorials.tsx:15
 msgid "Learn about the easiest way to embed a Geolonia map in your website."
-msgstr "ウェブサイトに Geolonia の地図を埋め込む最も簡単な方法についてご紹介します。"
+msgstr ""
+"ウェブサイトに Geolonia の地図を埋め込む最も簡単な方法についてご紹介します。"
 
 #: src/components/Turorials.tsx:19
 msgid "Embed API"
@@ -965,7 +961,9 @@ msgstr "Embed API"
 
 #: src/components/Turorials.tsx:20
 msgid "The Embed API allows you to set up a map with just a simple HTML code."
-msgstr "Embed API を使用すると、簡単な HTML を記述するだけで地図を設置することが可能です。"
+msgstr ""
+"Embed API を使用すると、簡単な HTML を記述するだけで地図を設置することが可能"
+"です。"
 
 #: src/components/Turorials.tsx:24
 msgid "JavaScript API"
@@ -974,7 +972,8 @@ msgstr "JavaScript API"
 #: src/components/Turorials.tsx:25
 msgid ""
 "Learn how to develop a professional map application using the JavaScript API."
-msgstr "JavaScript API を使った本格的な地図アプリの開発方法についてご紹介します。"
+msgstr ""
+"JavaScript API を使った本格的な地図アプリの開発方法についてご紹介します。"
 
 #: src/components/Turorials.tsx:29
 msgid "Custom Style"
@@ -1248,6 +1247,24 @@ msgstr ""
 msgctxt "Default value of zoom level of map"
 msgid "0"
 msgstr "6"
+
+#~ msgid "Display a map"
+#~ msgstr "地図の表示"
+
+#~ msgid "Create API key then add the map to your web site"
+#~ msgstr "API キーを作成してWebサイトに地図を追加"
+
+#~ msgid "Upload your data"
+#~ msgstr "データをアップロード"
+
+#~ msgid "Display CSV or GeoJSON in your map"
+#~ msgstr "CSV / GeoJSON を地図に表示"
+
+#~ msgid "Build a custom map"
+#~ msgstr "カスタムマップを作成"
+
+#~ msgid "Browse developer docs"
+#~ msgstr "開発者ドキュメントを参照"
 
 #~ msgid "Developer Documents"
 #~ msgstr "マニュアル"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -22,35 +22,39 @@ msgstr "招待が有効化されました。"
 msgid "Your invitation has been outdated."
 msgstr "この招待は無効です。"
 
-#: src/components/Dashboard.tsx:56
+#: src/components/Dashboard.tsx:57
 msgid "Get started with Geolonia map"
 msgstr "Geoloniaの地図を使ってみる"
 
-#: src/components/Dashboard.tsx:60
+#: src/components/Dashboard.tsx:61
 msgid "Display a map"
 msgstr "地図の表示"
 
-#: src/components/Dashboard.tsx:62
+#: src/components/Dashboard.tsx:63
 msgid "Create API key then add the map to your web site"
 msgstr "API キーを作成してWebサイトに地図を追加"
 
-#: src/components/Dashboard.tsx:66
+#: src/components/Dashboard.tsx:67
 msgid "Upload your data"
 msgstr "データをアップロード"
 
-#: src/components/Dashboard.tsx:68
+#: src/components/Dashboard.tsx:69
 msgid "Display CSV or GeoJSON in your map"
 msgstr "CSV / GeoJSON を地図に表示"
 
-#: src/components/Dashboard.tsx:72
+#: src/components/Dashboard.tsx:73
 msgid "Build a custom map"
 msgstr "カスタムマップを作成"
 
-#: src/components/Dashboard.tsx:74
+#: src/components/Dashboard.tsx:75
 msgid "Browse developer docs"
 msgstr "開発者ドキュメントを参照"
 
-#: src/components/Dashboard.tsx:80
+#: src/components/Dashboard.tsx:81
+msgid "Tutorials"
+msgstr "チュートリアル"
+
+#: src/components/Dashboard.tsx:84
 msgid "Developer's Blog"
 msgstr "Developer's Blog"
 
@@ -141,7 +145,7 @@ msgstr ""
 "エラー: それぞれの `feature` の `id` は GeoJSON の中で一意である必要がありま"
 "す。"
 
-#: src/components/Data/GeoJsonMeta.tsx:353 src/components/Data/fields.tsx:26
+#: src/components/Data/GeoJsonMeta.tsx:354 src/components/Data/fields.tsx:26
 #: src/components/Maps/APIKey.tsx:211 src/components/Navigator.tsx:320
 #: src/components/Team/general/fields.tsx:84
 #: src/components/User/profile.tsx:129 src/components/custom/AddNew.tsx:37
@@ -149,7 +153,7 @@ msgstr ""
 msgid "Name"
 msgstr "名前"
 
-#: src/components/Data/GeoJsonMeta.tsx:392
+#: src/components/Data/GeoJsonMeta.tsx:393
 msgid ""
 "Public features will be displayed publicly and anyone can download this "
 "features without API key."
@@ -157,23 +161,23 @@ msgstr ""
 "Public のデータは一般に公開され、だれでも API キー無しでダウンロードすること"
 "ができます。"
 
-#: src/components/Data/GeoJsonMeta.tsx:425
+#: src/components/Data/GeoJsonMeta.tsx:426
 msgid "Datasets are published now."
 msgstr "データセットは公開されています。"
 
-#: src/components/Data/GeoJsonMeta.tsx:427
+#: src/components/Data/GeoJsonMeta.tsx:428
 msgid "Datasets status are draft now."
 msgstr "データセットは下書きの状態です。"
 
-#: src/components/Data/GeoJsonMeta.tsx:440
+#: src/components/Data/GeoJsonMeta.tsx:441
 msgid "Advanced Settings"
 msgstr "高度な設定"
 
-#: src/components/Data/GeoJsonMeta.tsx:444
+#: src/components/Data/GeoJsonMeta.tsx:445
 msgid "Access allowed URLs"
 msgstr "アクセスを許可したURL"
 
-#: src/components/Data/GeoJsonMeta.tsx:445
+#: src/components/Data/GeoJsonMeta.tsx:446
 msgid ""
 "If you want to add more URLs to the \"URLs to allow access\" set on the API "
 "key page, please use the following settings. (e.g., if you want to use "
@@ -182,46 +186,46 @@ msgstr ""
 "APIキーページで設定した「アクセスを許可するURL」に、URLを追加したい場合は、以"
 "下より設定して下さい。(例：ひとつのタイルに複数のAPIキーを使用する場合)"
 
-#: src/components/Data/GeoJsonMeta.tsx:448
+#: src/components/Data/GeoJsonMeta.tsx:449
 msgid "URLs from API Key page."
 msgstr "API キーページで設定した URL"
 
-#: src/components/Data/GeoJsonMeta.tsx:454
+#: src/components/Data/GeoJsonMeta.tsx:455
 msgid "Enter URLs to be added."
 msgstr "追加する URL を入力して下さい"
 
-#: src/components/Data/GeoJsonMeta.tsx:479 src/components/Maps/APIKey.tsx:294
+#: src/components/Data/GeoJsonMeta.tsx:480 src/components/Maps/APIKey.tsx:294
 msgid "Add the map to your site"
 msgstr "ウェブサイトに地図を追加しましょう"
 
-#: src/components/Data/GeoJsonMeta.tsx:482 src/components/Maps/APIKey.tsx:297
+#: src/components/Data/GeoJsonMeta.tsx:483 src/components/Maps/APIKey.tsx:297
 msgid "Step 1"
 msgstr "ステップ 1"
 
-#: src/components/Data/GeoJsonMeta.tsx:484
+#: src/components/Data/GeoJsonMeta.tsx:485
 msgid "Please select API key."
 msgstr "API キーを選択してください"
 
-#: src/components/Data/GeoJsonMeta.tsx:486
+#: src/components/Data/GeoJsonMeta.tsx:487
 msgid "API key"
 msgstr "API キー"
 
-#: src/components/Data/GeoJsonMeta.tsx:494
+#: src/components/Data/GeoJsonMeta.tsx:495
 msgid "None"
 msgstr "未選択"
 
-#: src/components/Data/GeoJsonMeta.tsx:500
+#: src/components/Data/GeoJsonMeta.tsx:501
 msgid ""
 "If you don't have one, create it from <a href='#/api-keys'>API Keys</a>."
 msgstr ""
 "API キーをお持ちでない場合は <a href='#/api-keys'>API Keys</a> から作成して下"
 "さい。"
 
-#: src/components/Data/GeoJsonMeta.tsx:505 src/components/Maps/APIKey.tsx:324
+#: src/components/Data/GeoJsonMeta.tsx:506 src/components/Maps/APIKey.tsx:324
 msgid "Step 2"
 msgstr "ステップ 2"
 
-#: src/components/Data/GeoJsonMeta.tsx:509 src/components/Maps/APIKey.tsx:301
+#: src/components/Data/GeoJsonMeta.tsx:510 src/components/Maps/APIKey.tsx:301
 msgid ""
 "Include the following code before closing tag of the <code>&lt;body /&gt;</"
 "code> in your HTML file."
@@ -230,31 +234,31 @@ msgstr ""
 "のコードを挿入してください。API キーはすでに埋め込まれているのでそのままコ"
 "ピーして貼り付けできます。"
 
-#: src/components/Data/GeoJsonMeta.tsx:532 src/components/Maps/APIKey.tsx:343
+#: src/components/Data/GeoJsonMeta.tsx:533 src/components/Maps/APIKey.tsx:343
 msgid "Step 3"
 msgstr "ステップ 3"
 
-#: src/components/Data/GeoJsonMeta.tsx:535 src/components/Maps/APIKey.tsx:327
+#: src/components/Data/GeoJsonMeta.tsx:536 src/components/Maps/APIKey.tsx:327
 msgid ""
 "Click following button and get HTML code where you want to place the map."
 msgstr ""
 "以下のボタンをクリックして地図を表示したい場所の HTML を取得、Webサイトで地図"
 "を表示したい場所に挿入してください。"
 
-#: src/components/Data/GeoJsonMeta.tsx:553 src/components/Maps/APIKey.tsx:339
+#: src/components/Data/GeoJsonMeta.tsx:554 src/components/Maps/APIKey.tsx:339
 msgid "Get HTML"
 msgstr "HTML を取得"
 
-#: src/components/Data/GeoJsonMeta.tsx:557
+#: src/components/Data/GeoJsonMeta.tsx:558
 msgid "Step 4"
 msgstr "ステップ 4"
 
-#: src/components/Data/GeoJsonMeta.tsx:559 src/components/Maps/APIKey.tsx:345
+#: src/components/Data/GeoJsonMeta.tsx:560 src/components/Maps/APIKey.tsx:345
 msgid "Adjust the element size."
 msgstr ""
 "下記のCSSをWebサイトに追加して、地図を表示する要素のサイズを調整して下さい。"
 
-#: src/components/Data/GeoJsonMeta.tsx:574 src/components/Maps/APIKey.tsx:360
+#: src/components/Data/GeoJsonMeta.tsx:575 src/components/Maps/APIKey.tsx:360
 msgid "Copy to Clipboard"
 msgstr "クリップボードにコピー"
 
@@ -947,6 +951,47 @@ msgstr "メンバーの一時停止"
 msgid "The following members will be suspended:"
 msgstr "以下のメンバーによる操作が一時停止されます。"
 
+#: src/components/Turorials.tsx:14
+msgid "Get Started"
+msgstr "Get Started"
+
+#: src/components/Turorials.tsx:15
+msgid "Learn about the easiest way to embed a Geolonia map in your website."
+msgstr "ウェブサイトに Geolonia の地図を埋め込む最も簡単な方法についてご紹介します。"
+
+#: src/components/Turorials.tsx:19
+msgid "Embed API"
+msgstr "Embed API"
+
+#: src/components/Turorials.tsx:20
+msgid "The Embed API allows you to set up a map with just a simple HTML code."
+msgstr "Embed API を使用すると、簡単な HTML を記述するだけで地図を設置することが可能です。"
+
+#: src/components/Turorials.tsx:24
+msgid "JavaScript API"
+msgstr "JavaScript API"
+
+#: src/components/Turorials.tsx:25
+msgid ""
+"Learn how to develop a professional map application using the JavaScript API."
+msgstr "JavaScript API を使った本格的な地図アプリの開発方法についてご紹介します。"
+
+#: src/components/Turorials.tsx:29
+msgid "Custom Style"
+msgstr "カスタムスタイル"
+
+#: src/components/Turorials.tsx:30
+msgid "Learn how to customize the style of your map."
+msgstr "地図のスタイルをカスタマイズする方法についてご紹介します。"
+
+#: src/components/Turorials.tsx:34
+msgid "Support"
+msgstr "サポート"
+
+#: src/components/Turorials.tsx:35 src/components/custom/Support.tsx:22
+msgid "Contact Geolonia"
+msgstr "お問い合わせ"
+
 #: src/components/User/User.tsx:24
 msgid "Your profile"
 msgstr "プロフィール"
@@ -1046,10 +1091,6 @@ msgstr "利用規約"
 #: src/components/custom/Support.tsx:18
 msgid "Privacy"
 msgstr "プライバシー"
-
-#: src/components/custom/Support.tsx:22
-msgid "Contact Geolonia"
-msgstr "お問い合わせ"
 
 #: src/components/custom/coming-soon.tsx:30
 msgid "Coming soon"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -38,7 +38,7 @@ msgid ""
 "After that, add the generated HTML code snippet to your website to display "
 "the map you have created."
 msgstr ""
-"そのあと生成された HTML コードスニペットをあなたの Webサイトに追加すると、作"
+"その後、生成された HTML コードスニペットをあなたの Webサイトに追加すると、作"
 "成した地図が表示されます。"
 
 #: src/components/Dashboard.tsx:57

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -11,35 +11,39 @@ msgstr ""
 msgid "Your invitation has been outdated."
 msgstr ""
 
-#: src/components/Dashboard.tsx:56
+#: src/components/Dashboard.tsx:57
 msgid "Get started with Geolonia map"
 msgstr ""
 
-#: src/components/Dashboard.tsx:60
+#: src/components/Dashboard.tsx:61
 msgid "Display a map"
 msgstr ""
 
-#: src/components/Dashboard.tsx:62
+#: src/components/Dashboard.tsx:63
 msgid "Create API key then add the map to your web site"
 msgstr ""
 
-#: src/components/Dashboard.tsx:66
+#: src/components/Dashboard.tsx:67
 msgid "Upload your data"
 msgstr ""
 
-#: src/components/Dashboard.tsx:68
+#: src/components/Dashboard.tsx:69
 msgid "Display CSV or GeoJSON in your map"
 msgstr ""
 
-#: src/components/Dashboard.tsx:72
+#: src/components/Dashboard.tsx:73
 msgid "Build a custom map"
 msgstr ""
 
-#: src/components/Dashboard.tsx:74
+#: src/components/Dashboard.tsx:75
 msgid "Browse developer docs"
 msgstr ""
 
-#: src/components/Dashboard.tsx:80
+#: src/components/Dashboard.tsx:81
+msgid "Tutorials"
+msgstr ""
+
+#: src/components/Dashboard.tsx:84
 msgid "Developer's Blog"
 msgstr ""
 
@@ -131,7 +135,7 @@ msgstr ""
 msgid "Error: The `id` of each `fueature` must be unique in the GeoJSON."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:353
+#: src/components/Data/GeoJsonMeta.tsx:354
 #: src/components/Data/fields.tsx:26
 #: src/components/Maps/APIKey.tsx:211
 #: src/components/Navigator.tsx:320
@@ -142,106 +146,106 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:392
+#: src/components/Data/GeoJsonMeta.tsx:393
 msgid ""
 "Public features will be displayed publicly and anyone can download this "
 "features without API key."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:425
+#: src/components/Data/GeoJsonMeta.tsx:426
 msgid "Datasets are published now."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:427
+#: src/components/Data/GeoJsonMeta.tsx:428
 msgid "Datasets status are draft now."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:440
+#: src/components/Data/GeoJsonMeta.tsx:441
 msgid "Advanced Settings"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:444
+#: src/components/Data/GeoJsonMeta.tsx:445
 msgid "Access allowed URLs"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:445
+#: src/components/Data/GeoJsonMeta.tsx:446
 msgid ""
 "If you want to add more URLs to the \"URLs to allow access\" set on the API "
 "key page, please use the following settings. (e.g., if you want to use "
 "multiple API keys for a single tile, etc.)"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:448
+#: src/components/Data/GeoJsonMeta.tsx:449
 msgid "URLs from API Key page."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:454
+#: src/components/Data/GeoJsonMeta.tsx:455
 msgid "Enter URLs to be added."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:479
+#: src/components/Data/GeoJsonMeta.tsx:480
 #: src/components/Maps/APIKey.tsx:294
 msgid "Add the map to your site"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:482
+#: src/components/Data/GeoJsonMeta.tsx:483
 #: src/components/Maps/APIKey.tsx:297
 msgid "Step 1"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:484
+#: src/components/Data/GeoJsonMeta.tsx:485
 msgid "Please select API key."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:486
+#: src/components/Data/GeoJsonMeta.tsx:487
 msgid "API key"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:494
+#: src/components/Data/GeoJsonMeta.tsx:495
 msgid "None"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:500
+#: src/components/Data/GeoJsonMeta.tsx:501
 msgid "If you don't have one, create it from <a href='#/api-keys'>API Keys</a>."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:505
+#: src/components/Data/GeoJsonMeta.tsx:506
 #: src/components/Maps/APIKey.tsx:324
 msgid "Step 2"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:509
+#: src/components/Data/GeoJsonMeta.tsx:510
 #: src/components/Maps/APIKey.tsx:301
 msgid ""
 "Include the following code before closing tag of the <code>&lt;body "
 "/&gt;</code> in your HTML file."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:532
+#: src/components/Data/GeoJsonMeta.tsx:533
 #: src/components/Maps/APIKey.tsx:343
 msgid "Step 3"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:535
+#: src/components/Data/GeoJsonMeta.tsx:536
 #: src/components/Maps/APIKey.tsx:327
 msgid "Click following button and get HTML code where you want to place the map."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:553
+#: src/components/Data/GeoJsonMeta.tsx:554
 #: src/components/Maps/APIKey.tsx:339
 msgid "Get HTML"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:557
+#: src/components/Data/GeoJsonMeta.tsx:558
 msgid "Step 4"
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:559
+#: src/components/Data/GeoJsonMeta.tsx:560
 #: src/components/Maps/APIKey.tsx:345
 msgid "Adjust the element size."
 msgstr ""
 
-#: src/components/Data/GeoJsonMeta.tsx:574
+#: src/components/Data/GeoJsonMeta.tsx:575
 #: src/components/Maps/APIKey.tsx:360
 msgid "Copy to Clipboard"
 msgstr ""
@@ -918,6 +922,49 @@ msgstr ""
 msgid "The following members will be suspended:"
 msgstr ""
 
+#: src/components/Turorials.tsx:14
+msgid "Get Started"
+msgstr ""
+
+#: src/components/Turorials.tsx:15
+msgid "Learn about the easiest way to embed a Geolonia map in your website."
+msgstr ""
+
+#: src/components/Turorials.tsx:19
+msgid "Embed API"
+msgstr ""
+
+#: src/components/Turorials.tsx:20
+msgid "The Embed API allows you to set up a map with just a simple HTML code."
+msgstr ""
+
+#: src/components/Turorials.tsx:24
+msgid "JavaScript API"
+msgstr ""
+
+#: src/components/Turorials.tsx:25
+msgid ""
+"Learn how to develop a professional map application using the JavaScript "
+"API."
+msgstr ""
+
+#: src/components/Turorials.tsx:29
+msgid "Custom Style"
+msgstr ""
+
+#: src/components/Turorials.tsx:30
+msgid "Learn how to customize the style of your map."
+msgstr ""
+
+#: src/components/Turorials.tsx:34
+msgid "Support"
+msgstr ""
+
+#: src/components/Turorials.tsx:35
+#: src/components/custom/Support.tsx:22
+msgid "Contact Geolonia"
+msgstr ""
+
 #: src/components/User/User.tsx:24
 msgid "Your profile"
 msgstr ""
@@ -1020,10 +1067,6 @@ msgstr ""
 
 #: src/components/custom/Support.tsx:18
 msgid "Privacy"
-msgstr ""
-
-#: src/components/custom/Support.tsx:22
-msgid "Contact Geolonia"
 msgstr ""
 
 #: src/components/custom/coming-soon.tsx:30

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -11,39 +11,31 @@ msgstr ""
 msgid "Your invitation has been outdated."
 msgstr ""
 
-#: src/components/Dashboard.tsx:57
+#: src/components/Dashboard.tsx:55
 msgid "Get started with Geolonia map"
 msgstr ""
 
+#: src/components/Dashboard.tsx:56
+msgid ""
+"First, you need to obtain an API key and set up the initial settings for "
+"the map design and display position."
+msgstr ""
+
+#: src/components/Dashboard.tsx:56
+msgid ""
+"After that, add the generated HTML code snippet to your website to display "
+"the map you have created."
+msgstr ""
+
+#: src/components/Dashboard.tsx:57
+msgid "Create map"
+msgstr ""
+
 #: src/components/Dashboard.tsx:61
-msgid "Display a map"
-msgstr ""
-
-#: src/components/Dashboard.tsx:63
-msgid "Create API key then add the map to your web site"
-msgstr ""
-
-#: src/components/Dashboard.tsx:67
-msgid "Upload your data"
-msgstr ""
-
-#: src/components/Dashboard.tsx:69
-msgid "Display CSV or GeoJSON in your map"
-msgstr ""
-
-#: src/components/Dashboard.tsx:73
-msgid "Build a custom map"
-msgstr ""
-
-#: src/components/Dashboard.tsx:75
-msgid "Browse developer docs"
-msgstr ""
-
-#: src/components/Dashboard.tsx:81
 msgid "Tutorials"
 msgstr ""
 
-#: src/components/Dashboard.tsx:84
+#: src/components/Dashboard.tsx:64
 msgid "Developer's Blog"
 msgstr ""
 
@@ -99,7 +91,7 @@ msgstr ""
 #: src/components/Data/GeoJson.tsx:99
 #: src/components/Data/GeoJsons.tsx:91
 #: src/components/Maps/APIKey.tsx:114
-#: src/components/Maps/APIKeys.tsx:35
+#: src/components/Maps/APIKeys.tsx:38
 #: src/components/Navigator.tsx:265
 #: src/components/Team/Billing.tsx:173
 msgid "Home"
@@ -412,7 +404,7 @@ msgid "Logout"
 msgstr ""
 
 #: src/components/Maps/APIKey.tsx:118
-#: src/components/Maps/APIKeys.tsx:69
+#: src/components/Maps/APIKeys.tsx:81
 #: src/components/Navigator.tsx:153
 msgid "API keys"
 msgstr ""
@@ -455,24 +447,24 @@ msgstr ""
 msgid "Your API Key"
 msgstr ""
 
-#: src/components/Maps/APIKeys.tsx:63
+#: src/components/Maps/APIKeys.tsx:66
 msgid "(No date)"
 msgstr ""
 
 #: src/components/Maps/APIKeys.tsx:71
-msgid "You need an API key to display map. Get an API key."
-msgstr ""
-
-#: src/components/Maps/APIKeys.tsx:75
 msgid "Create a new API key"
 msgstr ""
 
-#: src/components/Maps/APIKeys.tsx:76
+#: src/components/Maps/APIKeys.tsx:72
 msgid "Please enter the name of new API key."
 msgstr ""
 
-#: src/components/Maps/APIKeys.tsx:77
+#: src/components/Maps/APIKeys.tsx:73
 msgid "My API"
+msgstr ""
+
+#: src/components/Maps/APIKeys.tsx:84
+msgid "You need an API key to display map. Get an API key."
 msgstr ""
 
 #: src/components/Navigator.tsx:109


### PR DESCRIPTION
Closes #438

修正内容

トップページに「地図を作成する」ボタンを追加。クリックすると https://app.geolonia.com/#/api-keys に飛ぶ。

![スクリーンショット 2021-08-03 13 55 36](https://user-images.githubusercontent.com/8760841/127960072-3f6435ba-c722-4bcd-ab59-161468d39045.png)

初回（APIキー未作成）の場合は、「地図の作成にはAPIキーが必要です。「新規作成」をクリックしてAPIキーを作成してください。」を表示。

（↑ 検証のためには、チームを新規作成してAPIキーが0件の状態にしてください）

![スクリーンショット 2021-08-03 13 56 23](https://user-images.githubusercontent.com/8760841/127960213-cb1c2546-79cf-47a7-92a4-08f4444e7edd.png)

2回目からは表示なし。

![スクリーンショット 2021-08-03 13 55 57](https://user-images.githubusercontent.com/8760841/127960321-6929e412-256c-4a92-a25d-6b69f617a12d.png)


