### PR TITLE
Move mixpanel token to .env.development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,3 +2,4 @@ REACT_APP_STAGE=dev
 REACT_APP_API_BASE="https://api.geolonia.com"
 REACT_APP_APP_API_BASE="https://api.app.geolonia.com"
 REACT_APP_TILE_SERVER="https://tileserver-dev.geolonia.com"
+REACT_APP_MIXPANEL_TOKEN=7a365e861ed4ee35992a503f79c25701

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,9 +19,7 @@ if (process.env.REACT_APP_SENTRY_DSN) {
   });
 }
 
-if (process.env.REACT_APP_MIXPANEL_TOKEN) {
-  mixpanel.init(process.env.REACT_APP_MIXPANEL_TOKEN);
-}
+mixpanel.init(process.env.REACT_APP_MIXPANEL_TOKEN as string);
 
 ReactDOM.render(<App />, document.getElementById("root"));
 


### PR DESCRIPTION
debug とか test とかのオプションが色々あったけど、両方設定しても送信されていたのでapi-dev環境用のtokenをデフォルトで埋め込みました。