### PR TITLE
ダッシュボード左下のGeoJSON API説明文言 修正

### DIFF
--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -196,7 +196,7 @@
       "Documentation": ["ドキュメント"],
       "Official Documents": ["公式ドキュメント"],
       "The dashboard has been renewed. The GeoJSON API that we used to provide is currently not accessible due to functional modifications. If you need to download the data, please <a href=\"https://geolonia.com/contact/\" target=\"_blank\">contact us</a>.": [
-        "ダッシュボードのリニューアルを行いました。以前提供していた GeoJSON API は機能改修を行っており、管理画面は現在アクセスできません。データのダウンロードが必要な場合、<a href=\"https://geolonia.com/contact/\" target=\"_blank\">ご連絡ください</a>。"
+        "8月5日にダッシュボードの正式版を公開しました。ベータ版で提供していたGeoJSON APIは、近日中に公開予定です。ベータ版で作成したデータはそのままお使いいただけますが、ダウンロードが必要な場合はお手数ですが別途 <a href=\"https://geolonia.com/contact/\" target=\"_blank\">ご連絡</a>をお願いします。"
       ],
       "Create a new team": ["新しいチームを作成"],
       "Please enter the name of new team.": [

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -542,10 +542,10 @@ msgid ""
 "download the data, please <a href=\"https://geolonia.com/contact/\" target="
 "\"_blank\">contact us</a>."
 msgstr ""
-"ダッシュボードのリニューアルを行いました。以前提供していた GeoJSON API は機能"
-"改修を行っており、管理画面は現在アクセスできません。データのダウンロードが必"
-"要な場合、<a href=\"https://geolonia.com/contact/\" target=\"_blank\">ご連絡"
-"ください</a>。"
+"8月5日にダッシュボードの正式版を公開しました。ベータ"
+"版で提供していたGeoJSON APIは、近日中に公開予定です。ベータ版で作成したデータはそのままお使いいただけま"
+"すが、ダウンロードが必要な場合はお手数ですが別途 <a href=\"https://geolonia."
+"com/contact/\" target=\"_blank\">ご連絡</a>をお願いします。"
 
 #: src/components/Navigator.tsx:316
 msgid "Create a new team"
@@ -985,50 +985,50 @@ msgstr "メンバーの一時停止"
 msgid "The following members will be suspended:"
 msgstr "以下のメンバーによる操作が一時停止されます。"
 
-#: src/components/Turorials.tsx:17
+#: src/components/Tutorials.tsx:16
 msgid "How to use the Dashboard"
 msgstr "管理画面の使い方"
 
-#: src/components/Turorials.tsx:18
+#: src/components/Tutorials.tsx:17
 msgid "Learn about the easiest way to embed a Geolonia map in your website."
 msgstr ""
 "ウェブサイトに Geolonia の地図を埋め込む最も簡単な方法についてご紹介します。"
 
-#: src/components/Turorials.tsx:23
+#: src/components/Tutorials.tsx:22
 msgid "Embed API"
 msgstr "Embed API"
 
-#: src/components/Turorials.tsx:24
+#: src/components/Tutorials.tsx:23
 msgid "The Embed API allows you to set up a map with just a simple HTML code."
 msgstr "Embed API を使用すると、簡単な HTML を書くだけで地図を設置出来ます。"
 
-#: src/components/Turorials.tsx:29
+#: src/components/Tutorials.tsx:28
 msgid "JavaScript API"
 msgstr "JavaScript API"
 
-#: src/components/Turorials.tsx:30
+#: src/components/Tutorials.tsx:29
 msgid ""
 "Learn how to develop a professional map application using the JavaScript API."
 msgstr ""
 "JavaScript API を使った本格的な地図アプリの開発方法についてご紹介します。"
 
-#: src/components/Turorials.tsx:35
+#: src/components/Tutorials.tsx:34
 msgid "Custom Style"
 msgstr "カスタムスタイル"
 
-#: src/components/Turorials.tsx:36
+#: src/components/Tutorials.tsx:35
 msgid "Learn how to customize the style of your map."
 msgstr "地図のスタイルをカスタマイズする方法についてご紹介します。"
 
-#: src/components/Turorials.tsx:38
+#: src/components/Tutorials.tsx:37
 msgid "Read More"
 msgstr "続きを読む"
 
-#: src/components/Turorials.tsx:41
+#: src/components/Tutorials.tsx:40
 msgid "Support"
 msgstr "サポート"
 
-#: src/components/Turorials.tsx:42
+#: src/components/Tutorials.tsx:41
 msgid ""
 "Please contact us if you have any questions about how to use the admin panel "
 "or if you need technical support (which may be paid)."
@@ -1036,7 +1036,7 @@ msgstr ""
 "管理画面の使い方の質問や、有償の技術サポートはこちらからお問い合わせくださ"
 "い。"
 
-#: src/components/Turorials.tsx:44
+#: src/components/Tutorials.tsx:43
 msgid "Contact support"
 msgstr "問い合わせる"
 

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -938,55 +938,55 @@ msgstr ""
 msgid "The following members will be suspended:"
 msgstr ""
 
-#: src/components/Turorials.tsx:17
+#: src/components/Tutorials.tsx:16
 msgid "How to use the Dashboard"
 msgstr ""
 
-#: src/components/Turorials.tsx:18
+#: src/components/Tutorials.tsx:17
 msgid "Learn about the easiest way to embed a Geolonia map in your website."
 msgstr ""
 
-#: src/components/Turorials.tsx:23
+#: src/components/Tutorials.tsx:22
 msgid "Embed API"
 msgstr ""
 
-#: src/components/Turorials.tsx:24
+#: src/components/Tutorials.tsx:23
 msgid "The Embed API allows you to set up a map with just a simple HTML code."
 msgstr ""
 
-#: src/components/Turorials.tsx:29
+#: src/components/Tutorials.tsx:28
 msgid "JavaScript API"
 msgstr ""
 
-#: src/components/Turorials.tsx:30
+#: src/components/Tutorials.tsx:29
 msgid ""
 "Learn how to develop a professional map application using the JavaScript "
 "API."
 msgstr ""
 
-#: src/components/Turorials.tsx:35
+#: src/components/Tutorials.tsx:34
 msgid "Custom Style"
 msgstr ""
 
-#: src/components/Turorials.tsx:36
+#: src/components/Tutorials.tsx:35
 msgid "Learn how to customize the style of your map."
 msgstr ""
 
-#: src/components/Turorials.tsx:38
+#: src/components/Tutorials.tsx:37
 msgid "Read More"
 msgstr ""
 
-#: src/components/Turorials.tsx:41
+#: src/components/Tutorials.tsx:40
 msgid "Support"
 msgstr ""
 
-#: src/components/Turorials.tsx:42
+#: src/components/Tutorials.tsx:41
 msgid ""
 "Please contact us if you have any questions about how to use the admin "
 "panel or if you need technical support (which may be paid)."
 msgstr ""
 
-#: src/components/Turorials.tsx:44
+#: src/components/Tutorials.tsx:43
 msgid "Contact support"
 msgstr ""
 


### PR DESCRIPTION
Closes #483 

少し長いかなと思って文章を削ってみました。どうでしょうか…？（でも原案でも良い様な気もしつつ。。）

## 原案
<img width="256" alt="スクリーンショット 2021-08-04 17 20 33 pngのコピー2" src="https://user-images.githubusercontent.com/8760841/128148838-b77b1f91-9a6a-4c62-8ca9-e670a94a6f04.png">

## 短縮版

<img width="256" alt="スクリーンショット 2021-08-04 17 28 33" src="https://user-images.githubusercontent.com/8760841/128148922-494bcc09-a017-4e2e-acb4-09729ed0ebe0.png">
