### PR TITLE
表記揺れ対応

### DIFF
--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -218,7 +218,7 @@ const Billing = (props: StateProps) => {
   return (
     <StripeContainer>
       <div className="billing">
-        <Title title="Billing" breadcrumb={breadcrumbItems}>
+        <Title title={__("Billing")} breadcrumb={breadcrumbItems}>
           {__("You can see subscriptions for this team in this month.")}
         </Title>
 

--- a/src/components/Team/general/index.tsx
+++ b/src/components/Team/general/index.tsx
@@ -20,12 +20,12 @@ type OwnProps = Record<string, never>;
 type StateProps = { role?: Geolonia.Role };
 type Props = OwnProps & StateProps;
 
-const Content = (props: Props) => {
+const General = (props: Props) => {
   const { role } = props;
 
   const breadcrumbItems = [
     {
-      title: "Home",
+      title: __("Home"),
       href: "#/"
     },
     {
@@ -69,4 +69,4 @@ const mapStateToProps = (state: Geolonia.Redux.AppState): StateProps => {
   return { role };
 };
 
-export default connect(mapStateToProps)(Content);
+export default connect(mapStateToProps)(General);

--- a/src/components/Team/members/index.tsx
+++ b/src/components/Team/members/index.tsx
@@ -42,7 +42,7 @@ type StateProps = {
 
 type Props = OwnProps & StateProps;
 
-const Content = (props: Props) => {
+const Members = (props: Props) => {
   const { members } = props;
   const [currentMember, setCurrentMember] = useState<
     false | Geolonia.Member
@@ -118,7 +118,7 @@ const Content = (props: Props) => {
 
   const breadcrumbItems = [
     {
-      title: "Home",
+      title: __("Home"),
       href: "#/"
     },
     {
@@ -140,7 +140,7 @@ const Content = (props: Props) => {
 
   return (
     <div>
-      <Title title="Members" breadcrumb={breadcrumbItems}>
+      <Title title={__("Members")} breadcrumb={breadcrumbItems}>
         {__("You can manage members in your team.")}
 
         { isOwner && inviteDisabled &&
@@ -308,4 +308,4 @@ export const mapStateToProps = (state: Geolonia.Redux.AppState): StateProps => {
   return { team, members };
 };
 
-export default connect(mapStateToProps)(Content);
+export default connect(mapStateToProps)(Members);

--- a/src/components/Tutorials.tsx
+++ b/src/components/Tutorials.tsx
@@ -20,7 +20,7 @@ const getTutorialContents = () => {
     },
     {
       title: __('Embed API'),
-      excerpt: __('The Embed API allows you to set up a map with just a simple HTML code.'),
+      excerpt: __('Learn about the Embed API, which enables you to set up a map with a simple HTML code.'),
       url: 'https://docs.geolonia.com/embed-api/',
       btnText: __('Read More')
     },

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -7,10 +7,10 @@ import Avatar from "./avatar";
 import Title from "../custom/Title";
 import { __ } from "@wordpress/i18n";
 
-const Content = () => {
+const User = () => {
   const breadcrumbItems = [
     {
-      title: "Home",
+      title: __("Home"),
       href: "#/"
     },
     {
@@ -39,4 +39,4 @@ const Content = () => {
   );
 };
 
-export default Content;
+export default User;

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -354,7 +354,7 @@
       "The following members will be suspended:": [
         "以下のメンバーによる操作が一時停止されます。"
       ],
-      "How to use the Dashboard": ["管理画面の使い方"],
+      "How to use the Dashboard": ["ダッシュボードの使い方"],
       "Learn about the easiest way to embed a Geolonia map in your website.": [
         "ウェブサイトに Geolonia の地図を埋め込む最も簡単な方法についてご紹介します。"
       ],
@@ -373,7 +373,7 @@
       "Read More": ["続きを読む"],
       "Support": ["サポート"],
       "Please contact us if you have any questions about how to use the admin panel or if you need technical support (which may be paid).": [
-        "管理画面の使い方の質問や、有償の技術サポートはこちらからお問い合わせください。"
+        "ダッシュボードの使い方の質問や、有償の技術サポートはこちらからお問い合わせください。"
       ],
       "Contact support": ["問い合わせる"],
       "Your profile": ["プロフィール"],

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -359,8 +359,8 @@
         "ウェブサイトに Geolonia の地図を埋め込む最も簡単な方法についてご紹介します。"
       ],
       "Embed API": ["Embed API"],
-      "The Embed API allows you to set up a map with just a simple HTML code.": [
-        "Embed API を使用すると、簡単な HTML を書くだけで地図を設置出来ます。"
+      "Learn about the Embed API, which enables you to set up a map with a simple HTML code.": [
+        "簡単な HTML を書くだけで地図を設置できる Embed API について紹介します。"
       ],
       "JavaScript API": ["JavaScript API"],
       "Learn how to develop a professional map application using the JavaScript API.": [

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -360,7 +360,7 @@
       ],
       "Embed API": ["Embed API"],
       "Learn about the Embed API, which enables you to set up a map with a simple HTML code.": [
-        "簡単な HTML を書くだけで地図を設置できる Embed API について紹介します。"
+        "簡単な HTML を書くだけで地図を設置できる Embed API についてご紹介します。"
       ],
       "JavaScript API": ["JavaScript API"],
       "Learn how to develop a professional map application using the JavaScript API.": [

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -105,6 +105,8 @@ msgstr "データを地図に追加しています。"
 #: src/components/Data/GeoJson.tsx:99 src/components/Data/GeoJsons.tsx:91
 #: src/components/Maps/APIKey.tsx:116 src/components/Maps/APIKeys.tsx:44
 #: src/components/Navigator.tsx:265 src/components/Team/Billing.tsx:173
+#: src/components/Team/general/index.tsx:28
+#: src/components/Team/members/index.tsx:121 src/components/User/User.tsx:13
 msgid "Home"
 msgstr "ホーム"
 
@@ -141,7 +143,7 @@ msgstr ""
 "す。"
 
 #: src/components/Data/GeoJsonMeta.tsx:354 src/components/Data/fields.tsx:26
-#: src/components/Navigator.tsx:326 src/components/Team/general/fields.tsx:84
+#: src/components/Navigator.tsx:340 src/components/Team/general/fields.tsx:84
 #: src/components/User/profile.tsx:129 src/components/custom/AddNew.tsx:37
 #: src/components/custom/Delete.tsx:121
 msgid "Name"
@@ -511,11 +513,11 @@ msgstr "My team"
 msgid "General"
 msgstr "一般"
 
-#: src/components/Navigator.tsx:136
+#: src/components/Navigator.tsx:136 src/components/Team/members/index.tsx:143
 msgid "Members"
 msgstr "メンバー"
 
-#: src/components/Navigator.tsx:145
+#: src/components/Navigator.tsx:145 src/components/Team/Billing.tsx:221
 msgid "Billing"
 msgstr "支払い"
 
@@ -535,31 +537,31 @@ msgstr "ドキュメント"
 msgid "Official Documents"
 msgstr "公式ドキュメント"
 
-#: src/components/Navigator.tsx:303
+#: src/components/Navigator.tsx:317
 msgid ""
 "The dashboard has been renewed. The GeoJSON API that we used to provide is "
 "currently not accessible due to functional modifications. If you need to "
 "download the data, please <a href=\"https://geolonia.com/contact/\" target="
 "\"_blank\">contact us</a>."
 msgstr ""
-"8月5日にダッシュボードの正式版を公開しました。ベータ"
-"版で提供していたGeoJSON APIは、近日中に公開予定です。ベータ版で作成したデータはそのままお使いいただけま"
-"すが、ダウンロードが必要な場合はお手数ですが別途 <a href=\"https://geolonia."
-"com/contact/\" target=\"_blank\">ご連絡</a>をお願いします。"
+"8月5日にダッシュボードの正式版を公開しました。ベータ版で提供していたGeoJSON "
+"APIは、近日中に公開予定です。ベータ版で作成したデータはそのままお使いいただけ"
+"ますが、ダウンロードが必要な場合はお手数ですが別途 <a href=\"https://"
+"geolonia.com/contact/\" target=\"_blank\">ご連絡</a>をお願いします。"
 
-#: src/components/Navigator.tsx:316
+#: src/components/Navigator.tsx:330
 msgid "Create a new team"
 msgstr "新しいチームを作成"
 
-#: src/components/Navigator.tsx:320
+#: src/components/Navigator.tsx:334
 msgid "Please enter the name of new team."
 msgstr "新しいチームの名前を入力してください。"
 
-#: src/components/Navigator.tsx:334 src/components/Team/general/fields.tsx:116
+#: src/components/Navigator.tsx:348 src/components/Team/general/fields.tsx:116
 msgid "Billing email"
 msgstr "支払い"
 
-#: src/components/Navigator.tsx:341 src/components/Team/general/fields.tsx:138
+#: src/components/Navigator.tsx:355 src/components/Team/general/fields.tsx:138
 msgid "We'll send you an email receipt."
 msgstr "指定したメールに請求情報を送信します。"
 
@@ -683,10 +685,11 @@ msgid ""
 "service</a> and <a class=\"MuiTypography-colorPrimary\" href=\"https://"
 "geolonia.com/privacy\" target=\"_blank\">Privacy policy</a>."
 msgstr ""
-"サインアップすることで、私たちの <a href=\"https://geolonia.com/terms\" target=\"_blank\" "
-"class=\"MuiTypography-colorPrimary\">利用規約</a> 及び <a class="
-"\"MuiTypography-colorPrimary\" href=\"https://geolonia.com/privacy\" target=\"_blank\">プライバ"
-"シーポリシー</a> に同意したものとさせていただきます。"
+"サインアップすることで、私たちの <a href=\"https://geolonia.com/terms\" "
+"target=\"_blank\" class=\"MuiTypography-colorPrimary\">利用規約</a> 及び <a "
+"class=\"MuiTypography-colorPrimary\" href=\"https://geolonia.com/privacy\" "
+"target=\"_blank\">プライバシーポリシー</a> に同意したものとさせていただきま"
+"す。"
 
 #: src/components/Team/Billing.tsx:102
 msgid "Free plan"
@@ -995,7 +998,7 @@ msgstr "以下のメンバーによる操作が一時停止されます。"
 
 #: src/components/Tutorials.tsx:16
 msgid "How to use the Dashboard"
-msgstr "管理画面の使い方"
+msgstr "ダッシュボードの使い方"
 
 #: src/components/Tutorials.tsx:17
 msgid "Learn about the easiest way to embed a Geolonia map in your website."
@@ -1041,8 +1044,8 @@ msgid ""
 "Please contact us if you have any questions about how to use the admin panel "
 "or if you need technical support (which may be paid)."
 msgstr ""
-"管理画面の使い方の質問や、有償の技術サポートはこちらからお問い合わせくださ"
-"い。"
+"ダッシュボードの使い方の質問や、有償の技術サポートはこちらからお問い合わせく"
+"ださい。"
 
 #: src/components/Tutorials.tsx:43
 msgid "Contact support"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -1010,8 +1010,8 @@ msgid "Embed API"
 msgstr "Embed API"
 
 #: src/components/Tutorials.tsx:23
-msgid "The Embed API allows you to set up a map with just a simple HTML code."
-msgstr "Embed API を使用すると、簡単な HTML を書くだけで地図を設置出来ます。"
+msgid "Learn about the Embed API, which enables you to set up a map with a simple HTML code."
+msgstr "簡単な HTML を書くだけで地図を設置できる Embed API について紹介します。"
 
 #: src/components/Tutorials.tsx:28
 msgid "JavaScript API"

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -1011,7 +1011,7 @@ msgstr "Embed API"
 
 #: src/components/Tutorials.tsx:23
 msgid "Learn about the Embed API, which enables you to set up a map with a simple HTML code."
-msgstr "簡単な HTML を書くだけで地図を設置できる Embed API について紹介します。"
+msgstr "簡単な HTML を書くだけで地図を設置できる Embed API についてご紹介します。"
 
 #: src/components/Tutorials.tsx:28
 msgid "JavaScript API"

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -94,6 +94,9 @@ msgstr ""
 #: src/components/Maps/APIKeys.tsx:44
 #: src/components/Navigator.tsx:265
 #: src/components/Team/Billing.tsx:173
+#: src/components/Team/general/index.tsx:28
+#: src/components/Team/members/index.tsx:121
+#: src/components/User/User.tsx:13
 msgid "Home"
 msgstr ""
 
@@ -129,7 +132,7 @@ msgstr ""
 
 #: src/components/Data/GeoJsonMeta.tsx:354
 #: src/components/Data/fields.tsx:26
-#: src/components/Navigator.tsx:326
+#: src/components/Navigator.tsx:340
 #: src/components/Team/general/fields.tsx:84
 #: src/components/User/profile.tsx:129
 #: src/components/custom/AddNew.tsx:37
@@ -483,10 +486,12 @@ msgid "General"
 msgstr ""
 
 #: src/components/Navigator.tsx:136
+#: src/components/Team/members/index.tsx:143
 msgid "Members"
 msgstr ""
 
 #: src/components/Navigator.tsx:145
+#: src/components/Team/Billing.tsx:221
 msgid "Billing"
 msgstr ""
 
@@ -506,7 +511,7 @@ msgstr ""
 msgid "Official Documents"
 msgstr ""
 
-#: src/components/Navigator.tsx:303
+#: src/components/Navigator.tsx:317
 msgid ""
 "The dashboard has been renewed. The GeoJSON API that we used to provide is "
 "currently not accessible due to functional modifications. If you need to "
@@ -514,20 +519,20 @@ msgid ""
 "target=\"_blank\">contact us</a>."
 msgstr ""
 
-#: src/components/Navigator.tsx:316
+#: src/components/Navigator.tsx:330
 msgid "Create a new team"
 msgstr ""
 
-#: src/components/Navigator.tsx:320
+#: src/components/Navigator.tsx:334
 msgid "Please enter the name of new team."
 msgstr ""
 
-#: src/components/Navigator.tsx:334
+#: src/components/Navigator.tsx:348
 #: src/components/Team/general/fields.tsx:116
 msgid "Billing email"
 msgstr ""
 
-#: src/components/Navigator.tsx:341
+#: src/components/Navigator.tsx:355
 #: src/components/Team/general/fields.tsx:138
 msgid "We'll send you an email receipt."
 msgstr ""

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -962,7 +962,9 @@ msgid "Embed API"
 msgstr ""
 
 #: src/components/Tutorials.tsx:23
-msgid "The Embed API allows you to set up a map with just a simple HTML code."
+msgid ""
+"Learn about the Embed API, which enables you to set up a map with a simple "
+"HTML code."
 msgstr ""
 
 #: src/components/Tutorials.tsx:28


### PR DESCRIPTION
- Embed API の紹介テキストを修正 (#484)、「Embed API を使用すると、簡単な HTML を書くだけで地図を設置出来ます。」-> 「簡単な HTML を書くだけで地図を設置できる Embed API について紹介します。」
- パンくずリストの英訳漏れ対応
- 管理画面 -> ダッシュボードに用語を統一