### PR TITLE
ダッシュボードの開発者ブログのレイアウトを4カラムにする

### DIFF
--- a/src/components/DeveloperBlog.tsx
+++ b/src/components/DeveloperBlog.tsx
@@ -30,10 +30,17 @@ const useStyles = makeStyles({
   date_published: {
     textAlign: 'right',
     marginTop: '0.5rem',
+    position: 'absolute',
+    right: 0,
+    bottom: 0,
   },
   title: {
     lineHeight: '1.4em',
     fontSize: '15px',
+  },
+  actionArea: {
+    height: '100%',
+    position: 'relative',
   },
 });
 
@@ -57,7 +64,7 @@ const Content = (props: Props) => {
           return (
             <Grid item lg={3} md={6} xs={12} key={index}>
               <Card className={classes.root}>
-                <CardActionArea onClick={() => window.open(post.url, '_blank')}>
+                <CardActionArea className={classes.actionArea} onClick={() => window.open(post.url, '_blank')}>
                   <CardMedia
                     className={classes.media}
                     image={`${post.thumbnail}-/resize/800x/-/format/auto/-/quality/lightest/`}

--- a/src/components/Tutorials.tsx
+++ b/src/components/Tutorials.tsx
@@ -47,7 +47,7 @@ const getTutorialContents = () => {
 
 const useStyles = makeStyles({
   root: {
-    height: '100%',
+
   },
   animationArea: {
 
@@ -62,7 +62,9 @@ const useStyles = makeStyles({
   icon: {
     marginRight: '10px',
   },
-  excerpt: {},
+  excerpt: {
+    minHeight: '60px',
+  },
   button: {
     color: '#EB5C0B',
     marginLeft: '13px',


### PR DESCRIPTION
Closes #549

修正内容

- 開発者ブログのレイアウトを4カラムに変更
- ブログカードのタイトルが大きかったので、geolonia.com の開発者ブログのカードに合わせる。
- チュートリアルカードの高さがバラバラだったのを統一。

修正を詰め込みすぎてすみません…🙇‍♂️

![スクリーンショット 2021-08-26 3 21 01](https://user-images.githubusercontent.com/8760841/130844566-93733dd9-bb46-443f-a5a6-7398166187ab.png)
