### PR TITLE
APIキー毎の合計表示回数をラベルに追加

### DIFF
--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -298,10 +298,6 @@ const Billing = (props: StateProps) => {
   };
 
   const options = {
-    interaction: {
-      mode: 'index',
-      intersect: false,
-    },
     responsive: true,
     scales: {
       x: {

--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -33,6 +33,7 @@ import customFetch from '../../lib/fetch';
 import { Redirect } from 'react-router';
 import { buildApiAppUrl } from '../../lib/api';
 import { colorScheme } from '../../lib/colorscheme';
+import { externalTooltipHandler } from '../../lib/billing-tooltip';
 
 const stripePromise = loadStripe(
   process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY as string,
@@ -269,9 +270,11 @@ const Billing = (props: StateProps) => {
         colorIndex = Math.random() * colorsMaxIndex;
       }
 
+      const totalCount = countData.reduce((accumulator, currentValue) => accumulator + currentValue);
+
       chartData.push(
         {
-          label: `${apiKeyName}: 500`,
+          label: `${apiKeyName} : ${totalCount}`,
           data: countData,
           fill: false,
           backgroundColor: colorScheme[colorIndex],
@@ -295,6 +298,10 @@ const Billing = (props: StateProps) => {
   };
 
   const options = {
+    interaction: {
+      mode: 'index',
+      intersect: false,
+    },
     responsive: true,
     scales: {
       x: {
@@ -302,6 +309,13 @@ const Billing = (props: StateProps) => {
       },
       y: {
         stacked: true,
+      },
+    },
+    plugins: {
+      tooltip: {
+        enabled: false,
+        position: 'nearest',
+        external: externalTooltipHandler,
       },
     },
   };

--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -271,7 +271,7 @@ const Billing = (props: StateProps) => {
 
       chartData.push(
         {
-          label: apiKeyName,
+          label: `${apiKeyName}: 500`,
           data: countData,
           fill: false,
           backgroundColor: colorScheme[colorIndex],

--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -429,7 +429,7 @@ const Billing = (props: StateProps) => {
         <Grid item xs={12} md={6} lg={3}>
           <Paper className="usage-card">
             <Typography component="h3">
-              {__('Map loads this month')}
+              {__('Map loads')}
             </Typography>
             <div className="usage-card-content">
               {!usage || typeof usage.count !== 'number' ? '-' : usage.count}

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -268,7 +268,7 @@
       "Usage this month": ["今月の利用状況"],
       "Billing period": ["請求対象期間"],
       "Next Payment Date": ["次回のお支払日"],
-      "Map loads this month": ["今月の地図の表示回数"],
+      "Map loads": ["地図の表示回数"],
       "Last updated %s": ["最終更新: %s"],
       "Charges": ["料金"],
       "Map loads by API key": ["API キー別の地図の表示回数"],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -59,7 +59,7 @@ msgstr "GeoJSON をダウンロード"
 
 #: src/components/Data/GeoJson.tsx:100 src/components/Data/GeoJsons.tsx:91
 #: src/components/Maps/APIKey.tsx:115 src/components/Maps/APIKeys.tsx:44
-#: src/components/Navigator.tsx:263 src/components/Team/Billing.tsx:320
+#: src/components/Navigator.tsx:263 src/components/Team/Billing.tsx:330
 #: src/components/Team/general/index.tsx:28
 #: src/components/Team/members/index.tsx:121 src/components/User/User.tsx:13
 msgid "Home"
@@ -724,60 +724,60 @@ msgstr ""
 "target=\"_blank\">プライバシーポリシー</a> に同意したものとさせていただきま"
 "す。"
 
-#: src/components/Team/Billing.tsx:146
+#: src/components/Team/Billing.tsx:147
 msgid "Free plan"
 msgstr "Free プラン"
 
-#: src/components/Team/Billing.tsx:170
+#: src/components/Team/Billing.tsx:171
 msgid "Free Plan"
 msgstr "Free プラン"
 
-#: src/components/Team/Billing.tsx:324 src/components/Team/general/index.tsx:32
+#: src/components/Team/Billing.tsx:334 src/components/Team/general/index.tsx:32
 #: src/components/Team/members/index.tsx:125
 msgid "Team settings"
 msgstr "チーム設定"
 
-#: src/components/Team/Billing.tsx:384
+#: src/components/Team/Billing.tsx:394
 msgid "Usage this month"
 msgstr "今月の利用状況"
 
-#: src/components/Team/Billing.tsx:390
+#: src/components/Team/Billing.tsx:400
 msgid "Billing period"
 msgstr "請求対象期間"
 
-#: src/components/Team/Billing.tsx:406
+#: src/components/Team/Billing.tsx:416
 msgid "Next Payment Date"
 msgstr "次回のお支払日"
 
-#: src/components/Team/Billing.tsx:422
-msgid "Map loads this month"
-msgstr "今月の地図の表示回数"
+#: src/components/Team/Billing.tsx:432
+msgid "Map loads"
+msgstr "地図の表示回数"
 
-#: src/components/Team/Billing.tsx:430
+#: src/components/Team/Billing.tsx:440
 msgid "Last updated %s"
 msgstr "最終更新: %s"
 
-#: src/components/Team/Billing.tsx:437
+#: src/components/Team/Billing.tsx:447
 msgid "Charges"
 msgstr "料金"
 
-#: src/components/Team/Billing.tsx:448
+#: src/components/Team/Billing.tsx:458
 msgid "Map loads by API key"
 msgstr "API キー別の地図の表示回数"
 
-#: src/components/Team/Billing.tsx:450
+#: src/components/Team/Billing.tsx:461
 msgid "API keys with no map loads will not be shown in the graph."
 msgstr "表示回数の無いAPIキーはグラフに表示されません。"
 
-#: src/components/Team/Billing.tsx:460
+#: src/components/Team/Billing.tsx:470
 msgid "Payment information"
 msgstr "支払い情報"
 
-#: src/components/Team/Billing.tsx:470
+#: src/components/Team/Billing.tsx:480
 msgid "Current account credit:"
 msgstr "クレジット残高"
 
-#: src/components/Team/Billing.tsx:474
+#: src/components/Team/Billing.tsx:484
 msgid ""
 " : While this account has credits available, payments will deduct from "
 "account credit instead of the registered credit card."
@@ -785,49 +785,49 @@ msgstr ""
 "　(現在、クレジットが適用されています。クレジット残高が残っている場合、請求は"
 "クレジット残高から支払われます。)"
 
-#: src/components/Team/Billing.tsx:479
+#: src/components/Team/Billing.tsx:489
 msgid "Payment method:"
 msgstr "支払い方法"
 
-#: src/components/Team/Billing.tsx:483
+#: src/components/Team/Billing.tsx:493
 msgid "ending in **%1$s"
 msgstr "クレジットカード（末尾の番号 **%1$s）"
 
-#: src/components/Team/Billing.tsx:493
+#: src/components/Team/Billing.tsx:503
 msgid "Change payment method"
 msgstr "支払い方法を変更"
 
-#: src/components/Team/Billing.tsx:505
+#: src/components/Team/Billing.tsx:515
 msgid "Current Plan"
 msgstr "現在のプラン"
 
-#: src/components/Team/Billing.tsx:511
+#: src/components/Team/Billing.tsx:521
 msgid "Scheduled to expire on %1$s"
 msgstr "%1$s にキャンセルされます"
 
-#: src/components/Team/Billing.tsx:530
+#: src/components/Team/Billing.tsx:540
 msgid "Resume subscription"
 msgstr "自動更新を再開"
 
-#: src/components/Team/Billing.tsx:542
+#: src/components/Team/Billing.tsx:552
 msgid "Change Plan"
 msgstr "プランを変更"
 
-#: src/components/Team/Billing.tsx:570
+#: src/components/Team/Billing.tsx:580
 msgid "Learn more about plans on the pricing page."
 msgstr "プラン詳細については、料金ページをご覧ください。"
 
-#: src/components/Team/Billing.tsx:580
+#: src/components/Team/Billing.tsx:590
 msgid "Billing and Plans"
 msgstr "料金プランとお支払い"
 
-#: src/components/Team/Billing.tsx:581
+#: src/components/Team/Billing.tsx:591
 msgid ""
 "You can check and change your current pricing plan and usage status of Team "
 "%s."
 msgstr "チーム「%s」の現在の料金プラン・利用状況の確認、変更ができます。"
 
-#: src/components/Team/Billing.tsx:590
+#: src/components/Team/Billing.tsx:600
 msgid "Payment history"
 msgstr "支払い履歴"
 
@@ -1394,8 +1394,8 @@ msgctxt "Default value of zoom level of map"
 msgid "0"
 msgstr "6"
 
-#~ msgid "Map loads"
-#~ msgstr "地図の表示回数"
+#~ msgid "Map loads this month"
+#~ msgstr "今月の地図の表示回数"
 
 #~ msgid "API Key"
 #~ msgstr "API キー"

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -48,7 +48,7 @@ msgstr ""
 #: src/components/Maps/APIKey.tsx:115
 #: src/components/Maps/APIKeys.tsx:44
 #: src/components/Navigator.tsx:263
-#: src/components/Team/Billing.tsx:320
+#: src/components/Team/Billing.tsx:330
 #: src/components/Team/general/index.tsx:28
 #: src/components/Team/members/index.tsx:121
 #: src/components/User/User.tsx:13
@@ -686,109 +686,109 @@ msgid ""
 "target=\"_blank\">Privacy policy</a>."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:146
+#: src/components/Team/Billing.tsx:147
 msgid "Free plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:170
+#: src/components/Team/Billing.tsx:171
 msgid "Free Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:324
+#: src/components/Team/Billing.tsx:334
 #: src/components/Team/general/index.tsx:32
 #: src/components/Team/members/index.tsx:125
 msgid "Team settings"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:384
+#: src/components/Team/Billing.tsx:394
 msgid "Usage this month"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:390
+#: src/components/Team/Billing.tsx:400
 msgid "Billing period"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:406
+#: src/components/Team/Billing.tsx:416
 msgid "Next Payment Date"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:422
-msgid "Map loads this month"
+#: src/components/Team/Billing.tsx:432
+msgid "Map loads"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:430
+#: src/components/Team/Billing.tsx:440
 msgid "Last updated %s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:437
+#: src/components/Team/Billing.tsx:447
 msgid "Charges"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:448
+#: src/components/Team/Billing.tsx:458
 msgid "Map loads by API key"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:450
+#: src/components/Team/Billing.tsx:461
 msgid "API keys with no map loads will not be shown in the graph."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:460
+#: src/components/Team/Billing.tsx:470
 msgid "Payment information"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:470
+#: src/components/Team/Billing.tsx:480
 msgid "Current account credit:"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:474
+#: src/components/Team/Billing.tsx:484
 msgid ""
 " : While this account has credits available, payments will deduct from "
 "account credit instead of the registered credit card."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:479
+#: src/components/Team/Billing.tsx:489
 msgid "Payment method:"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:483
+#: src/components/Team/Billing.tsx:493
 msgid "ending in **%1$s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:493
+#: src/components/Team/Billing.tsx:503
 msgid "Change payment method"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:505
+#: src/components/Team/Billing.tsx:515
 msgid "Current Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:511
+#: src/components/Team/Billing.tsx:521
 msgid "Scheduled to expire on %1$s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:530
+#: src/components/Team/Billing.tsx:540
 msgid "Resume subscription"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:542
+#: src/components/Team/Billing.tsx:552
 msgid "Change Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:570
+#: src/components/Team/Billing.tsx:580
 msgid "Learn more about plans on the pricing page."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:580
+#: src/components/Team/Billing.tsx:590
 msgid "Billing and Plans"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:581
+#: src/components/Team/Billing.tsx:591
 msgid ""
 "You can check and change your current pricing plan and usage status of Team "
 "%s."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:590
+#: src/components/Team/Billing.tsx:600
 msgid "Payment history"
 msgstr ""
 

--- a/src/lib/billing-tooltip.ts
+++ b/src/lib/billing-tooltip.ts
@@ -1,0 +1,115 @@
+const getOrCreateTooltip = (chart:any) => {
+  let tooltipEl = chart.canvas.parentNode.querySelector('div');
+
+  if (!tooltipEl) {
+    tooltipEl = document.createElement('div');
+    tooltipEl.style.background = 'rgba(0, 0, 0, 0.7)';
+    tooltipEl.style.borderRadius = '3px';
+    tooltipEl.style.color = 'white';
+    tooltipEl.style.opacity = 1;
+    tooltipEl.style.pointerEvents = 'none';
+    tooltipEl.style.position = 'absolute';
+    tooltipEl.style.transform = 'translate(-50%, 0)';
+    tooltipEl.style.transition = 'all .1s ease';
+
+    const table = document.createElement('table');
+    table.style.margin = '0px';
+
+    tooltipEl.appendChild(table);
+    chart.canvas.parentNode.appendChild(tooltipEl);
+  }
+
+  return tooltipEl;
+};
+
+export const externalTooltipHandler = (context:any) => {
+
+  // Tooltip Element
+  const {chart, tooltip} = context;
+  const tooltipEl = getOrCreateTooltip(chart);
+
+  // Hide if no tooltip
+  if (tooltip.opacity === 0) {
+    tooltipEl.style.opacity = 0;
+    return;
+  }
+
+  // Set Text
+  if (tooltip.body) {
+    const titleLines = tooltip.title || [];
+    const bodyLines = tooltip.body.map((b:any) => b.lines);
+
+    const tableHead = document.createElement('thead');
+
+    titleLines.forEach((title:any) => {
+      const tr = document.createElement('tr');
+
+      tr.style.borderWidth = '0';
+
+      const th = document.createElement('th');
+      th.style.borderWidth = '0';
+      const text = document.createTextNode(title);
+
+      th.appendChild(text);
+      tr.appendChild(th);
+      tableHead.appendChild(tr);
+    });
+
+    const tableBody = document.createElement('tbody');
+    bodyLines.forEach((body:any, i:any) => {
+      const colors = tooltip.labelColors[i];
+
+      const span = document.createElement('span');
+      span.style.background = colors.backgroundColor;
+      span.style.borderColor = colors.borderColor;
+      span.style.borderWidth = '2px';
+      span.style.marginRight = '10px';
+      span.style.height = '10px';
+      span.style.width = '10px';
+      span.style.display = 'inline-block';
+
+      const tr = document.createElement('tr');
+      tr.style.backgroundColor = 'inherit';
+      tr.style.borderWidth = '0';
+
+      const td = document.createElement('td');
+      td.style.borderWidth = '0';
+
+      // ツールチップでは API キーの合計表示回数を削除
+      const usageDateIndex = body[0].lastIndexOf(':');
+      const usageDate = body[0].substring(usageDateIndex, body[0].length);
+
+      const labelWithSum = body[0].substring(0, usageDateIndex);
+
+      const labelIndex = labelWithSum.lastIndexOf(':');
+      const label = labelWithSum.substring(0, labelIndex);
+
+      const text = document.createTextNode(`${label}${usageDate}`);
+
+      td.appendChild(span);
+      td.appendChild(text);
+      tr.appendChild(td);
+      tableBody.appendChild(tr);
+    });
+
+    const tableRoot = tooltipEl.querySelector('table');
+
+    // Remove old children
+    while (tableRoot.firstChild) {
+      tableRoot.firstChild.remove();
+    }
+
+    // Add new children
+    tableRoot.appendChild(tableHead);
+    tableRoot.appendChild(tableBody);
+  }
+
+  const {offsetLeft: positionX, offsetTop: positionY} = chart.canvas;
+
+  // Display, position, and set styles for font
+  tooltipEl.style.opacity = 1;
+  tooltipEl.style.left = `${positionX + tooltip.caretX}px`;
+  tooltipEl.style.top = `${positionY + tooltip.caretY}px`;
+  tooltipEl.style.font = tooltip.options.bodyFont.string;
+  tooltipEl.style.padding = `${tooltip.options.padding}px ${tooltip.options.padding}px`;
+};


### PR DESCRIPTION
Close #556 

APIキー毎の合計表示回数をラベルに追加しました。

ラベルに合計表示回数を追加すると、ツールチップにも合計表示回数を表示してしまったため、カスタムツールチップを作成する事で解決しました。


![スクリーンショット 2021-08-30 15 02 08](https://user-images.githubusercontent.com/8760841/131292595-848f7e80-831e-4078-8fa0-c7b496bfa166.png)
