### PR TITLE
支払いページの数字フォーマットの修正

### DIFF
--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -313,7 +313,7 @@ const Billing = (props: StateProps) => {
     }
 
     setDatasets(chartData);
-    setLabels(labelList.map((x) => x.format('MM/DD')));
+    setLabels(labelList.map((x) => x.format('M/D')));
 
   }, [usage, subscription, freePlanDetails, mapKeyNames]);
 
@@ -433,7 +433,7 @@ const Billing = (props: StateProps) => {
               <div className="usage-card-content">
                 {subOrFreePlan ?
                   <>
-                    {`${moment(subOrFreePlan.current_period_start).format('MM/DD')} ~ ${moment(subOrFreePlan.current_period_end).format('MM/DD')}`}
+                    {`${moment(subOrFreePlan.current_period_start).format('M/D')} ~ ${moment(subOrFreePlan.current_period_end).format('M/D')}`}
                   </>
                   :
                   '-'
@@ -449,7 +449,7 @@ const Billing = (props: StateProps) => {
               <div className="usage-card-content">
                 {subscription ?
                   <>
-                    {moment(subscription.current_period_end).format('MM/DD')}
+                    {moment(subscription.current_period_end).format('M/D')}
                   </>
                   :
                   '-'

--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -463,8 +463,8 @@ const Billing = (props: StateProps) => {
                 {__('Map loads')}
               </Typography>
               <div className="usage-card-content">
-                {!usage || typeof usage.count !== 'number' ? '-' : usage.count}
-                { (team && team.baseFreeMapLoadCount) && <small> / { team.baseFreeMapLoadCount.toLocaleString() }回</small> }
+                {!usage || typeof usage.count !== 'number' ? '-' : usage.count.toLocaleString()}
+                { (team && team.baseFreeMapLoadCount) && <small>{sprintf(__(' / %s loads'), team.baseFreeMapLoadCount.toLocaleString())}</small> }
               </div>
               {/* NOTE: 未更新時（usage.updated = 1970-01-01T00:00:00Z が API から返ってくる） は、非表示にする */ }
               {(usage?.updated && usage.updated >= '2000-01-01T00:00:00Z') && <>

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -269,6 +269,7 @@
       "Billing period": ["請求対象期間"],
       "Next Payment Date": ["次回のお支払日"],
       "Map loads": ["地図の表示回数"],
+      " / %s loads": [" / %s 回"],
       "Last updated %s": ["最終更新: %s"],
       "Charges": ["料金"],
       "Map loads by API key": ["API キー別の地図の表示回数"],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -750,6 +750,10 @@ msgstr "次回のお支払日"
 msgid "Map loads"
 msgstr "地図の表示回数"
 
+#: src/components/Team/Billing.tsx:467
+msgid " / %s loads"
+msgstr " / %s 回"
+
 #: src/components/Team/Billing.tsx:471
 msgid "Last updated %s"
 msgstr "最終更新: %s"
@@ -1690,9 +1694,6 @@ msgstr "6"
 
 #~ msgid "Free for up to 50,000/month"
 #~ msgstr "50,000/月 までは無料"
-
-#~ msgid "Loads"
-#~ msgstr "ロード回数"
 
 #~ msgid "Team Plan"
 #~ msgstr "チームプラン"

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -705,6 +705,10 @@ msgstr ""
 msgid "Map loads"
 msgstr ""
 
+#: src/components/Team/Billing.tsx:467
+msgid " / %s loads"
+msgstr ""
+
 #: src/components/Team/Billing.tsx:471
 msgid "Last updated %s"
 msgstr ""


### PR DESCRIPTION
- 地図ロードの `回` の i18nize
- 地図ロードの回数のカンマ桁区切りの追加
- `MM/DD` の日付は `M/D` に変更（`請求対象期間 9/1 ~ 10/1`のような表記の場合はこちらの方が日付を弁別しやすいものと思います）

<img width="1440" alt="スクリーンショット 2021-09-08 17 26 11" src="https://user-images.githubusercontent.com/6292312/132474176-f3ba0c4b-1ed0-40a7-a6ba-a0e34e708735.png">
