### PR TITLE
チーム表示のデザイン崩れを修正

### DIFF
--- a/src/components/Navigator.scss
+++ b/src/components/Navigator.scss
@@ -20,3 +20,7 @@
   height: auto;
   margin-right: 16px;
 }
+
+#navigator .MuiSelect-select {
+  width: 110px;
+}


### PR DESCRIPTION
Fix #338 
あまり綺麗な解決方法とは思えないですが..
もっといい方法ありましたら教えていただけますと 🙇 

<img width="319" alt="スクリーンショット 2021-09-08 22 49 48" src="https://user-images.githubusercontent.com/6292312/132522295-42ecdc68-bb1d-480e-aac3-88f66fd96ad8.png">
