### PR TITLE
Fix bar color and refactor

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,3 +1,5 @@
+@import "./variables.scss";
+
 .App {
   text-align: center;
 }

--- a/src/components/Header.scss
+++ b/src/components/Header.scss
@@ -1,13 +1,15 @@
+@import '../variables.scss';
+
 header{
   &.MuiPaper-root{
     background-color: #fff !important;
     padding: 7px !important;
   }
   .iconButtonAvatar{
-    border: 1px solid #EB5C0B;
+    border: 1px solid $color-primary;
     margin-right: 10px;
     svg{
-      fill: #EB5C0B;
+      fill: $color-primary;
     }
   }
   .iconButtonlogo{
@@ -17,7 +19,7 @@ header{
     }
   }
   .MuiSvgIcon-root{
-    fill: #EB5C0B;
+    fill: $color-primary;
   }
 }
 

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -39,6 +39,7 @@ import { useLocation } from 'react-router-dom';
 
 // types
 import Redux from 'redux';
+import { colorPrimary } from '../variables';
 
 const styles = (theme: Theme) => ({
   categoryHeader: {
@@ -67,7 +68,7 @@ const styles = (theme: Theme) => ({
     color: theme.palette.common.white,
   },
   itemActiveItem: {
-    color: '#4fc3f7',
+    color: colorPrimary,
   },
   itemPrimary: {
     fontSize: 'inherit',

--- a/src/components/Tutorials.tsx
+++ b/src/components/Tutorials.tsx
@@ -10,6 +10,8 @@ import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
 
+import { colorPrimary } from '../variables';
+
 const getTutorialContents = () => {
   return [
     {
@@ -66,7 +68,7 @@ const useStyles = makeStyles({
     minHeight: '60px',
   },
   button: {
-    color: '#EB5C0B',
+    color: colorPrimary,
     marginLeft: '13px',
   },
 });
@@ -83,7 +85,7 @@ export const Tutorials: React.FC = () => {
             <CardContent  className={classes.content}>
               <div>
                 <div className={classes.titleBox}>
-                  <PlayCircleOutlineIcon className={classes.icon} style={{ color: '#EB5C0B' }}/>
+                  <PlayCircleOutlineIcon className={classes.icon} style={{ color: colorPrimary }}/>
                   <Typography variant="h6" component="h2">{post.title}</Typography>
                 </div>
                 <Typography variant="body2" color="textSecondary" component="p" className={classes.excerpt}>{post.excerpt}</Typography>

--- a/src/components/custom/Title.scss
+++ b/src/components/custom/Title.scss
@@ -1,8 +1,10 @@
+@import '../../variables.scss';
+
 .page-title
 {
   margin: 0 0 2em -0;
   border-bottom: 5px solid #dedede;
-  border-top: 5px solid #009BE5;
+  border-top: 5px solid $color-primary;
 
   .outer
   {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,5 @@
+@import './variables.scss';
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -17,9 +19,9 @@ code {
   padding: 16px;
 }
 
-a {color: #EB5C0B;}
+a {color: $color-primary;}
 .MuiTypography-colorPrimary{
-  color: #EB5C0B !important;
+  color: $color-primary !important;
 }
 
 .MuiButton-containedPrimary {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
+import './index.scss';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import * as Sentry from '@sentry/react';

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,0 +1,2 @@
+// NOTE: keep synced with variables.ts
+$color-primary: #EB5C0B;

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,2 @@
+// NOTE: keep synced with variables.scss
+export const colorPrimary = '#EB5C0B';


### PR DESCRIPTION
- バーの色をメインのオレンジに変更
- この色は CSS と JavaScript の両方で複数箇所で使っているので変数として括り出し
- #576 で設定したアクティブなメニューの色もこの色を採用

変更前:

<img width="561" alt="スクリーンショット 2021-09-09 14 30 37" src="https://user-images.githubusercontent.com/6292312/132644306-81e9561e-8b20-4a01-ae3a-66f3ff8dac7f.png">

変更後:

<img width="1441" alt="スクリーンショット 2021-09-09 16 42 03" src="https://user-images.githubusercontent.com/6292312/132644208-6fee1b2d-c941-43f5-83a5-31070d63f16d.png">


