### PR TITLE
支払い関係のダイアログのスタイル調整

### DIFF
--- a/src/components/Team/Billing/payment-method-modal.tsx
+++ b/src/components/Team/Billing/payment-method-modal.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useCallback } from 'react';
-import Modal from '@material-ui/core/Modal';
-import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { CircularProgress } from '@material-ui/core';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
 
 // Stripe
 import { CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
@@ -14,16 +16,6 @@ type Props = {
   open: boolean;
   handleClose: () => void;
   teamId: string;
-};
-
-const modalStyle: React.CSSProperties = {
-  position: 'absolute',
-  minWidth: 600,
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  background: 'white',
-  padding: '2em 4em 3em',
 };
 
 const PaymentMethodModal: React.FC<Props> = (props) => {
@@ -65,21 +57,20 @@ const PaymentMethodModal: React.FC<Props> = (props) => {
   }, [stripe, elements, updatePaymentMethod, teamId, handleClose]);
 
   return (
-    <Modal open={open} onClose={handleClose}>
-      <div style={modalStyle}>
-        <Typography component="h3">{__('Card information')}</Typography>
-        <div
-          style={{
-            margin: '1em 0 1em',
-            padding: '3px 1px 2px',
-          }}
-        >
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      fullWidth={true}
+      aria-labelledby={'register-payment-method'}
+    >
+      <form onSubmit={handleSubmit}>
+        <DialogTitle id={'register-payment-method'}>{__('Card information')}</DialogTitle>
+        <DialogContent>
           <CardElement
             options={{
               hidePostalCode: true,
               style: {
                 base: {
-                  padding: '16px',
                   fontSize: '16px',
                   color: '#424770',
                   '::placeholder': {
@@ -92,29 +83,32 @@ const PaymentMethodModal: React.FC<Props> = (props) => {
               },
             }}
           />
-        </div>
-        <p>{message}</p>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={(e) => {
-            e.preventDefault();
-            handleSubmit();
+          <p>{message}</p>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            style={{marginRight: 24}}
+            variant="contained"
+            color="primary"
+            onClick={(e) => {
+              e.preventDefault();
+              handleSubmit();
             // handleClose();
-          }}
-          type={'button'}
-        >
-          {loading && (
-            <CircularProgress
-              size={16}
-              style={{ marginRight: 8 }}
-              color={'inherit'}
-            />
-          )}
-          {__('Update')}
-        </Button>
-      </div>
-    </Modal>
+            }}
+            type={'button'}
+          >
+            {loading && (
+              <CircularProgress
+                size={16}
+                style={{ marginRight: 8 }}
+                color={'inherit'}
+              />
+            )}
+            {__('Update')}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
   );
 };
 

--- a/src/components/Team/Billing/plan-modal.tsx
+++ b/src/components/Team/Billing/plan-modal.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from 'react';
-import Modal from '@material-ui/core/Modal';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { __ } from '@wordpress/i18n';
@@ -10,6 +9,10 @@ import {
   Radio,
 } from '@material-ui/core';
 import Alert from '../../custom/Alert';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
 import { useUpdateTeamPlanMutation } from '../../../redux/apis/app-api';
 
 type PlanId = string | null | undefined;
@@ -20,15 +23,6 @@ type Props = {
   plans: Geolonia.Billing.Plan[];
   currentPlanId: PlanId;
   teamId: string;
-};
-const modalStyle: React.CSSProperties = {
-  position: 'absolute',
-  minWidth: 600,
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  background: 'white',
-  padding: '2em 4em 3em',
 };
 
 const useMessage = (
@@ -79,10 +73,16 @@ const PlanModal: React.FC<Props> = (props) => {
   });
 
   return (
-    <Modal open={open} onClose={handleClose}>
-      <div style={modalStyle}>
-        <Typography component="h2">{__('Your plan')}</Typography>
-        <div style={{ marginTop: '1em' }}>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      fullWidth={true}
+      aria-labelledby={'change-team-plan'}
+    >
+      <form action="">
+
+        <DialogTitle id={'change-team-plan'}>{__('Your plan')}</DialogTitle>
+        <DialogContent>
           {plans.map((plan) => (
             <RadioGroup key={plan.planId} name="plan">
               <FormControlLabel
@@ -109,6 +109,8 @@ const PlanModal: React.FC<Props> = (props) => {
           <Typography component="p" style={{ marginTop: '0.5em', marginBottom: '1em' }}>
             {__('All prices include a 10% Japanese Consumption Tax')}
           </Typography>
+        </DialogContent>
+        <DialogActions>
           <Button
             variant="contained"
             color="primary"
@@ -132,9 +134,9 @@ const PlanModal: React.FC<Props> = (props) => {
           { typeof alertMessage !== 'undefined' && <Alert>
             {alertMessage}
           </Alert>}
-        </div>
-      </div>
-    </Modal>
+        </DialogActions>
+      </form>
+    </Dialog>
   );
 };
 

--- a/src/components/Team/Billing/plan-modal.tsx
+++ b/src/components/Team/Billing/plan-modal.tsx
@@ -79,7 +79,7 @@ const PlanModal: React.FC<Props> = (props) => {
       fullWidth={true}
       aria-labelledby={'change-team-plan'}
     >
-      <form action="">
+      <form onSubmit={handleSubmit}>
 
         <DialogTitle id={'change-team-plan'}>{__('Your plan')}</DialogTitle>
         <DialogContent>


### PR DESCRIPTION
支払い関係のダイアログは、CSS を直書きしていたため一貫性のないスタイルになっていました。
Material UI のコンポーネントを使ってスタイルを他のダイアログ・モーダルと統一。
close #508

|変更前|変更後|
|:--|:--|
|<img width="703" alt="スクリーンショット 2021-09-14 14 03 21" src="https://user-images.githubusercontent.com/6292312/133199916-19c58efa-ef8b-4b39-b380-6e0b7da5db05.png">|<img width="759" alt="スクリーンショット 2021-09-14 14 20 49" src="https://user-images.githubusercontent.com/6292312/133199939-f0e025a0-9f41-4e23-84fd-5b7e2de59d88.png">|
|<img width="803" alt="スクリーンショット 2021-09-14 14 21 53" src="https://user-images.githubusercontent.com/6292312/133199958-a9ce7eff-4cee-437b-bfa4-add9432d612c.png">|<img width="724" alt="スクリーンショット 2021-09-14 14 25 09" src="https://user-images.githubusercontent.com/6292312/133199972-a5e5ccba-a1dc-4231-b719-0aebce78686e.png">|