### PR TITLE
Fix deletion confirmation text field label

### DIFF
--- a/src/components/custom/Delete.tsx
+++ b/src/components/custom/Delete.tsx
@@ -20,6 +20,7 @@ type Status = false | 'working' | 'success' | 'failure';
 type Props = {
   text1?: string;
   text2?: string;
+  textLabel?: string;
   answer?: string;
   errorMessage: string;
   onClick: () => Promise<any>;
@@ -31,12 +32,13 @@ type Props = {
 const getTexts = (props: Props) => ({
   text1: props.text1 || __('Are you sure you want to delete this item?'),
   text2: props.text2 || __('Please type as <code>delete</code> to confirm.'),
+  textLabel: props.textLabel || __('Enter and check'),
   answer: props.answer || 'delete',
 });
 
 export const Delete: React.FC<Props> = (props) => {
   const { disableCancel, disableDelete, onClick, onFailure } = props;
-  const { text1, text2 } = getTexts(props);
+  const { text1, text2, textLabel } = getTexts(props);
 
   const [open, setOpen] = useState(false);
   const [confirmation, setConfirmation] = useState('');
@@ -122,7 +124,7 @@ export const Delete: React.FC<Props> = (props) => {
               error
               margin="dense"
               name="name"
-              label={__('Name')}
+              label={textLabel}
               type="text"
               value={confirmation}
               onChange={(e) => setConfirmation(e.target.value)}

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -449,6 +449,7 @@
       "Please type as <code>delete</code> to confirm.": [
         "確認のためにデータセット名を入力してください。"
       ],
+      "Enter and check": ["入力して確認"],
       "Saved.": ["保存しました。"],
       "Failed to save.": ["保存できませんでした。"],
       "Terms": ["利用規約"],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -143,7 +143,7 @@ msgstr ""
 
 #: src/components/Data/GeoJsonMeta.tsx:353 src/components/Data/fields.tsx:26
 #: src/components/Navigator.tsx:328 src/components/User/profile.tsx:133
-#: src/components/custom/AddNew.tsx:37 src/components/custom/Delete.tsx:125
+#: src/components/custom/AddNew.tsx:37
 msgid "Name"
 msgstr "名前"
 
@@ -826,16 +826,16 @@ msgstr "今月の利用状況"
 msgid "No payment history."
 msgstr "支払い履歴はありません。"
 
-#: src/components/Team/Billing/payment-method-modal.tsx:114
-#: src/components/Team/Billing/plan-modal.tsx:129
+#: src/components/Team/Billing/payment-method-modal.tsx:107
+#: src/components/Team/Billing/plan-modal.tsx:131
 msgid "Update"
 msgstr "更新"
 
-#: src/components/Team/Billing/payment-method-modal.tsx:51
+#: src/components/Team/Billing/payment-method-modal.tsx:43
 msgid "Unknown Error."
 msgstr "不明なエラー。"
 
-#: src/components/Team/Billing/payment-method-modal.tsx:70
+#: src/components/Team/Billing/payment-method-modal.tsx:67
 msgid "Card information"
 msgstr "クレジットカード情報"
 
@@ -843,17 +843,17 @@ msgstr "クレジットカード情報"
 msgid "All prices include a 10% Japanese Consumption Tax"
 msgstr "※ 上記の価格はすべて税込表示です"
 
-#: src/components/Team/Billing/plan-modal.tsx:46
+#: src/components/Team/Billing/plan-modal.tsx:40
 msgid "Your subscription will be canceled."
 msgstr "サブスクリプションはキャンセルされます。"
 
-#: src/components/Team/Billing/plan-modal.tsx:48
+#: src/components/Team/Billing/plan-modal.tsx:42
 msgid ""
 "The difference between the plan changes will be charged or charged as a "
 "balance."
 msgstr "プランの変更に伴う差額が請求または残高としてチャージされます。"
 
-#: src/components/Team/Billing/plan-modal.tsx:69
+#: src/components/Team/Billing/plan-modal.tsx:63
 msgid ""
 "The plan could not be changed. If you are trying to downgrade your team to a "
 "team that supports fewer members, please remove the extra members before "
@@ -901,12 +901,12 @@ msgstr ""
 #: src/components/Team/members/remove-member.tsx:87
 #: src/components/Team/members/suspend.tsx:96
 #: src/components/custom/AddNew.tsx:155 src/components/custom/Cancel.tsx:18
-#: src/components/custom/Delete.tsx:141
+#: src/components/custom/Delete.tsx:143
 msgid "Cancel"
 msgstr "キャンセル"
 
 #: src/components/Team/general/delete.tsx:155
-#: src/components/custom/Delete.tsx:162
+#: src/components/custom/Delete.tsx:164
 msgid "Delete"
 msgstr "削除"
 
@@ -1246,13 +1246,17 @@ msgstr "次のページ"
 msgid "last page"
 msgstr "最後のページ"
 
-#: src/components/custom/Delete.tsx:32
+#: src/components/custom/Delete.tsx:33
 msgid "Are you sure you want to delete this item?"
 msgstr "本当にこのデータセットを削除しますか？"
 
-#: src/components/custom/Delete.tsx:33
+#: src/components/custom/Delete.tsx:34
 msgid "Please type as <code>delete</code> to confirm."
 msgstr "確認のためにデータセット名を入力してください。"
+
+#: src/components/custom/Delete.tsx:35
+msgid "Enter and check"
+msgstr "入力して確認"
 
 #: src/components/custom/Save.tsx:125
 msgid "Saved."

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -132,7 +132,6 @@ msgstr ""
 #: src/components/Navigator.tsx:328
 #: src/components/User/profile.tsx:133
 #: src/components/custom/AddNew.tsx:37
-#: src/components/custom/Delete.tsx:125
 msgid "Name"
 msgstr ""
 
@@ -779,16 +778,16 @@ msgstr ""
 msgid "No payment history."
 msgstr ""
 
-#: src/components/Team/Billing/payment-method-modal.tsx:114
-#: src/components/Team/Billing/plan-modal.tsx:129
+#: src/components/Team/Billing/payment-method-modal.tsx:107
+#: src/components/Team/Billing/plan-modal.tsx:131
 msgid "Update"
 msgstr ""
 
-#: src/components/Team/Billing/payment-method-modal.tsx:51
+#: src/components/Team/Billing/payment-method-modal.tsx:43
 msgid "Unknown Error."
 msgstr ""
 
-#: src/components/Team/Billing/payment-method-modal.tsx:70
+#: src/components/Team/Billing/payment-method-modal.tsx:67
 msgid "Card information"
 msgstr ""
 
@@ -796,17 +795,17 @@ msgstr ""
 msgid "All prices include a 10% Japanese Consumption Tax"
 msgstr ""
 
-#: src/components/Team/Billing/plan-modal.tsx:46
+#: src/components/Team/Billing/plan-modal.tsx:40
 msgid "Your subscription will be canceled."
 msgstr ""
 
-#: src/components/Team/Billing/plan-modal.tsx:48
+#: src/components/Team/Billing/plan-modal.tsx:42
 msgid ""
 "The difference between the plan changes will be charged or charged as a "
 "balance."
 msgstr ""
 
-#: src/components/Team/Billing/plan-modal.tsx:69
+#: src/components/Team/Billing/plan-modal.tsx:63
 msgid ""
 "The plan could not be changed. If you are trying to downgrade your team to "
 "a team that supports fewer members, please remove the extra members before "
@@ -851,12 +850,12 @@ msgstr ""
 #: src/components/Team/members/suspend.tsx:96
 #: src/components/custom/AddNew.tsx:155
 #: src/components/custom/Cancel.tsx:18
-#: src/components/custom/Delete.tsx:141
+#: src/components/custom/Delete.tsx:143
 msgid "Cancel"
 msgstr ""
 
 #: src/components/Team/general/delete.tsx:155
-#: src/components/custom/Delete.tsx:162
+#: src/components/custom/Delete.tsx:164
 msgid "Delete"
 msgstr ""
 
@@ -1186,12 +1185,16 @@ msgstr ""
 msgid "last page"
 msgstr ""
 
-#: src/components/custom/Delete.tsx:32
+#: src/components/custom/Delete.tsx:33
 msgid "Are you sure you want to delete this item?"
 msgstr ""
 
-#: src/components/custom/Delete.tsx:33
+#: src/components/custom/Delete.tsx:34
 msgid "Please type as <code>delete</code> to confirm."
+msgstr ""
+
+#: src/components/custom/Delete.tsx:35
+msgid "Enter and check"
 msgstr ""
 
 #: src/components/custom/Save.tsx:125


### PR DESCRIPTION
`名前` -> `入力して確認`

<img width="678" alt="スクリーンショット 2021-09-15 11 03 33" src="https://user-images.githubusercontent.com/6292312/133358369-c62bf0e4-8535-430f-aa8d-d0808547db35.png">

close #585