### PR TITLE
Give concreted Function.name property

### DIFF
--- a/src/components/Data/ExportButton.tsx
+++ b/src/components/Data/ExportButton.tsx
@@ -11,7 +11,7 @@ type Props = {
   drawObject: MapboxDraw;
 };
 
-const Content = (props: Props) => {
+const ExportButton = (props: Props) => {
   const { GeoJsonID, drawObject } = props;
 
   const downloadGeoJson = () => {
@@ -34,4 +34,4 @@ const Content = (props: Props) => {
   );
 };
 
-export default Content;
+export default ExportButton;

--- a/src/components/Data/ImportButton.tsx
+++ b/src/components/Data/ImportButton.tsx
@@ -8,7 +8,7 @@ type Props = {
   GeoJsonImporter: Function;
 };
 
-const Content = (props: Props) => {
+const ImportButton = (props: Props) => {
   const [stateImporter, setStateImporter] = useState<boolean>(false);
 
   const closeImporter = () => {
@@ -28,4 +28,4 @@ const Content = (props: Props) => {
   );
 };
 
-export default Content;
+export default ImportButton;

--- a/src/components/DeveloperBlog.tsx
+++ b/src/components/DeveloperBlog.tsx
@@ -44,17 +44,17 @@ const useStyles = makeStyles({
   },
 });
 
-const Content = (props: Props) => {
+const DeveloperBlog = (props: Props) => {
   const [blogItems, setBlogItems] = useState<BlogPost[]>([]);
   const classes = useStyles();
 
   useEffect(() => {
-    const endpoint = 'https://blog.geolonia.com/feed.json';
-    fetch(endpoint)
-      .then((res) => res.json())
-      .then((json) => {
-        setBlogItems(json.items);
-      });
+    (async () => {
+      const endpoint = 'https://blog.geolonia.com/feed.json';
+      const resp = await fetch(endpoint);
+      const json = await resp.json();
+      setBlogItems(json.items);
+    })();
   }, []);
 
   return (
@@ -84,4 +84,4 @@ const Content = (props: Props) => {
   );
 };
 
-export default Content;
+export default DeveloperBlog;

--- a/src/components/ForgotPassword.tsx
+++ b/src/components/ForgotPassword.tsx
@@ -23,7 +23,7 @@ type RouterProps = {
 type DispatchProps = Record<string, never>;
 type Props = OwnProps & RouterProps & DispatchProps;
 
-const Content = (props: Props) => {
+const Signin = (props: Props) => {
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<
     null | 'requesting' | 'success' | 'warning'
@@ -93,4 +93,4 @@ const Content = (props: Props) => {
   );
 };
 
-export default Content;
+export default Signin;

--- a/src/components/ResetPassword.tsx
+++ b/src/components/ResetPassword.tsx
@@ -22,7 +22,7 @@ import { pageTransitionInterval } from '../constants';
 import estimateLanguage from '../lib/estimate-language';
 import StatusIndication from './custom/status-indication';
 
-const Content = () => {
+const ResetPassword = () => {
   const parsed = queryString.parse(window.location.search);
   const qsusername = parsed.username as string;
 
@@ -171,4 +171,4 @@ const mapStateToProps = (state: Geolonia.Redux.AppState) => ({
   currentUser: state.authSupport.currentUser || '',
 });
 
-export default connect(mapStateToProps)(Content);
+export default connect(mapStateToProps)(ResetPassword);

--- a/src/components/Signin.tsx
+++ b/src/components/Signin.tsx
@@ -61,7 +61,7 @@ const Signin = (props: Props) => {
   const [errorMessage, setErrorMessage] = useState('');
   const [passwordResetFlag, setPasswordResetFlag] = useState(false);
   const [postVerifyFlag, setPostVerifyFlag] = useState(false);
-  const { fetchedEmail, isReady, acceptInvitationCallback } = useInvitationToken(window.location.search);
+  const { fetchedEmail, isReady, acceptInvitationCallback } = useInvitationToken();
 
   useEffect(() => {
     const parsed = queryString.parse(window.location.search);
@@ -215,6 +215,6 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch) => ({
   setAccessToken: (accessToken: string) =>
     dispatch(setAccessToken({accessToken})),
 });
-const ConnectedContent = connect(mapStateToProps, mapDispatchToProps)(Signin);
+const ConnectedSignin = connect(mapStateToProps, mapDispatchToProps)(Signin);
 
-export default ConnectedContent;
+export default ConnectedSignin;

--- a/src/components/custom/Support.tsx
+++ b/src/components/custom/Support.tsx
@@ -7,7 +7,7 @@ import './Support.scss';
 
 type Props = {};
 
-const Content = (props: Props) => {
+const Support = (props: Props) => {
   return (
     <div className="support-menu">
       <ul>
@@ -27,4 +27,4 @@ const Content = (props: Props) => {
   );
 };
 
-export default Content;
+export default Support;


### PR DESCRIPTION
変数名 が格納される `Function.name` のプロパティは React のコンポーネントのデバッグで使うので、具体的なものを与えるようにしました。