### PR TITLE
チーム削除のUI改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@wordpress/i18n": "^4.2.2",
     "amazon-cognito-identity-js": "^5.0.6",
     "chart.js": "^3.5.1",
+    "classnames": "^2.3.1",
     "clipboard-polyfill": "^3.0.3",
     "clsx": "^1.1.1",
     "interweave": "^12.8.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,6 +21,7 @@ import './Header.scss';
 import { useSession } from '../hooks/session';
 import { useGetUserQuery } from '../redux/apis/app-api';
 import { useImageFromURL } from '../redux/hooks';
+import classNames from 'classnames';
 
 const lightColor = 'rgba(255, 255, 255, 0.7)';
 
@@ -131,7 +132,7 @@ const Header: React.FC<Props> = (props: Props) => {
               <IconButton
                 onClick={handleClick}
                 color="inherit"
-                className={`iconButtonAvatar ${(classes.iconButtonAvatar)}`}
+                className={classNames('iconButtonAvatar', classes.iconButtonAvatar)}
               >
                 {userAvatar ? (
                   <Avatar src={userAvatar} style={avatarStyle} />

--- a/src/components/Navigator.scss
+++ b/src/components/Navigator.scss
@@ -19,6 +19,10 @@
   width: 48px;
   height: auto;
   margin-right: 16px;
+
+  &.is-team-fetching {
+    opacity: .5;
+  }
 }
 
 #navigator .MuiSelect-select {

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -31,7 +31,7 @@ import defaultTeamIcon from './custom/team.svg';
 import { Link } from '@material-ui/core';
 
 import { __ } from '@wordpress/i18n';
-
+import classNames from 'classnames';
 import { useLocation } from 'react-router-dom';
 
 // types
@@ -223,7 +223,7 @@ const Navigator: React.FC<Props> = (props) => {
         >
           <img
             src={ teamAvatar || defaultTeamIcon }
-            className={`logo${isTeamFetching ? ' is-team-fetching' : ''}`}
+            className={classNames('logo', isTeamFetching ? ' is-team-fetching' : '')}
             alt=""
           />
           { selectedTeam && !isTeamFetching &&

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -118,7 +118,7 @@ const Navigator: React.FC<Props> = (props) => {
 
   const { data: teams, refetch: refetchTeams, isFetching } = useGetTeamsQuery();
   const [selectingTeamId, setSelectingTeamId] = useState<string | null>(null);
-  const { selectedTeam, refetch: refetchTeam } = useSelectedTeam();
+  const { selectedTeam, refetch: refetchTeam, isFetching: isTeamFetching } = useSelectedTeam();
   const teamAvatar = useImageFromURL(
     selectedTeam?.teamId,
     selectedTeam?.links.getAvatar || '',
@@ -223,10 +223,10 @@ const Navigator: React.FC<Props> = (props) => {
         >
           <img
             src={ teamAvatar || defaultTeamIcon }
-            className="logo"
+            className={`logo${isTeamFetching ? ' is-team-fetching' : ''}`}
             alt=""
           />
-          { selectedTeam &&
+          { selectedTeam && !isTeamFetching &&
             <Select
               className="team"
               value={selectedTeam.teamId}

--- a/src/components/Paperbase.tsx
+++ b/src/components/Paperbase.tsx
@@ -34,6 +34,7 @@ import { __ } from '@wordpress/i18n';
 
 import { Roles } from '../constants';
 import mixpanel from 'mixpanel-browser';
+import classNames from 'classnames';
 
 const drawerWidth = 256;
 const styles = createStyles({
@@ -143,7 +144,7 @@ export const Paperbase: React.FC<Props> = (props: Props) => {
           <Route exact path="/forgot-password" component={ForgotPassword} />
           <Route exact path="/reset-password" component={ResetPassword} />
           <Route exact>
-            <nav className={`${classes.drawer} ${classes.headerColor}`}>
+            <nav className={classNames(classes.drawer, classes.headerColor)}>
               <Hidden smUp implementation="js">
                 <Navigator
                   PaperProps={{ style: { width: drawerWidth } }}

--- a/src/components/Team/general/delete.tsx
+++ b/src/components/Team/general/delete.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useContext, useEffect } from 'react';
 
 // Components
 import Typography from '@material-ui/core/Typography';
@@ -13,6 +13,8 @@ import {
   DialogActions,
 } from '@material-ui/core';
 import CheckIcon from '@material-ui/icons/Check';
+
+import { context as NotificationContext} from '../../../contexts/notification';
 
 // utils
 import { __, sprintf } from '@wordpress/i18n';
@@ -42,10 +44,19 @@ const TeamDeletion: React.FC = () => {
     false | 'requesting' | 'success' | 'failure'
   >(false);
 
+  // hooks
+  const { updateState: updateNotificationState } = useContext(NotificationContext);
   const { selectedTeam } = useSelectedTeam();
   const { data: teams } = useGetTeamsQuery();
-  const [ deleteTeam ] = useDeleteTeamMutation();
+  const [ deleteTeam, mutationResult ] = useDeleteTeamMutation();
   const teamLength = (teams && teams.length) || 0;
+
+  // handle error
+  useEffect(() => {
+    if (mutationResult.isError) {
+      updateNotificationState({ open: true, message: __('Unknown error.'), type: 'success' });
+    }
+  }, [mutationResult.isError, updateNotificationState]);
 
   const saveHandler = useCallback(async () => {
     if (!selectedTeam) return;

--- a/src/components/Team/members/invite.tsx
+++ b/src/components/Team/members/invite.tsx
@@ -9,6 +9,7 @@ import CloseIcon from '@material-ui/icons/Close';
 // Util
 import { sprintf, __ } from '@wordpress/i18n';
 import Interweave from 'interweave';
+import classNames from 'classnames';
 
 // redux
 import { useCreateTeamMemberInvitationMutation } from '../../../redux/apis/app-api';
@@ -72,7 +73,7 @@ export const Invite: React.FC<Props> = (props) => {
         saveButtonLabel={__('Send')}
       />
       <Snackbar
-        className={`snackbar-saved ${status}`}
+        className={classNames('snackbar-saved', status)}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -6,7 +6,6 @@ import {
   useGetPlansQuery,
   useGetTeamsQuery,
   useGetUserQuery,
-  useGetTeamPlanQuery,
 } from './apis/app-api';
 import { __ } from '@wordpress/i18n';
 import type { RootState, AppDispatch } from './store';
@@ -20,7 +19,6 @@ type SelectedTeamResult = {
   selectedTeam: Geolonia.Team | null
   isLoading: boolean,
   isFetching: boolean,
-  isRestricted: boolean | null,
   refetch: () => void
 }
 export const useSelectedTeam: () => SelectedTeamResult = () => {
@@ -30,9 +28,6 @@ export const useSelectedTeam: () => SelectedTeamResult = () => {
     skip: !isLoggedIn,
   });
   const selectedTeamId = useAppSelector((state) => state.team.selectedTeamId);
-  const { data: planDetails } = useGetTeamPlanQuery(selectedTeamId || '', {
-    skip: !selectedTeamId,
-  });
 
   const selectedTeam = useMemo(() => {
     if (isLoading || !teams) return null;
@@ -47,19 +42,11 @@ export const useSelectedTeam: () => SelectedTeamResult = () => {
     return teams.find((team) => team.teamId === selectedTeamId) || teams[0];
   }, [isLoading, dispatch, teams, selectedTeamId]);
 
-  let isRestricted = null;
-  if (selectedTeam && planDetails) {
-    const { baseFreeMapLoadCount, customMaxMapLoadCount } = selectedTeam;
-    const { count } = planDetails.usage;
-    isRestricted = count > (customMaxMapLoadCount || baseFreeMapLoadCount);
-  }
-
   return {
     selectedTeam,
     isLoading,
     isFetching,
     refetch,
-    isRestricted,
   };
 };
 

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -6,6 +6,7 @@ import {
   useGetPlansQuery,
   useGetTeamsQuery,
   useGetUserQuery,
+  useGetTeamPlanQuery,
 } from './apis/app-api';
 import { __ } from '@wordpress/i18n';
 import type { RootState, AppDispatch } from './store';
@@ -17,16 +18,21 @@ export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 type SelectedTeamResult = {
   selectedTeam: Geolonia.Team | null
-  isLoading: boolean
+  isLoading: boolean,
+  isFetching: boolean,
+  isRestricted: boolean | null,
   refetch: () => void
 }
 export const useSelectedTeam: () => SelectedTeamResult = () => {
   const dispatch = useAppDispatch();
   const isLoggedIn = useAppSelector((state) => state.authSupport.isLoggedIn);
-  const { data: teams, isLoading, refetch } = useGetTeamsQuery(undefined, {
+  const { data: teams, isLoading, refetch, isFetching } = useGetTeamsQuery(undefined, {
     skip: !isLoggedIn,
   });
   const selectedTeamId = useAppSelector((state) => state.team.selectedTeamId);
+  const { data: planDetails } = useGetTeamPlanQuery(selectedTeamId || '', {
+    skip: !selectedTeamId,
+  });
 
   const selectedTeam = useMemo(() => {
     if (isLoading || !teams) return null;
@@ -41,10 +47,19 @@ export const useSelectedTeam: () => SelectedTeamResult = () => {
     return teams.find((team) => team.teamId === selectedTeamId) || teams[0];
   }, [isLoading, dispatch, teams, selectedTeamId]);
 
+  let isRestricted = null;
+  if (selectedTeam && planDetails) {
+    const { baseFreeMapLoadCount, customMaxMapLoadCount } = selectedTeam;
+    const { count } = planDetails.usage;
+    isRestricted = count > (customMaxMapLoadCount || baseFreeMapLoadCount);
+  }
+
   return {
     selectedTeam,
     isLoading,
+    isFetching,
     refetch,
+    isRestricted,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3967,6 +3967,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"


### PR DESCRIPTION
- チーム関連の修正
  - 削除すると再度チームを選択し直してデータを Fetch するので、その間はチームを選べないように修正
  - エラーハンドリング追加
- className プロパティで複数のクラスをくっつけるときは classnames ライブラリを使うように　
- CI の問題: しばらく develop ブランチに更新がないとキャッシュが消えてバンドルサイズのレポートができなくなっていた。しょうがないのでキャッシュがないときはレポートしないように修正

![Nov-09-2021 08-43-08](https://user-images.githubusercontent.com/6292312/140835830-a7201322-db27-4772-b0d4-87915d7ffee5.gif)
