### PR TITLE
Fix signup param key

### DIFF
--- a/src/components/custom/languages.tsx
+++ b/src/components/custom/languages.tsx
@@ -10,7 +10,7 @@ type LanguagesData = {
 
 type urlParams = {
   lang: string,
-  referrer?: string
+  ref?: string
 }
 
 const Languages = () => {
@@ -37,7 +37,7 @@ const Languages = () => {
           };
 
           if (referrer) {
-            params.referrer = referrer;
+            params.ref = referrer;
           }
 
           const urlSearchParam = new URLSearchParams(params).toString();

--- a/src/lib/signup-referrer.ts
+++ b/src/lib/signup-referrer.ts
@@ -2,7 +2,7 @@ import queryString from 'query-string';
 
 const signupReferrer = () => {
 
-  let referrer = queryString.parse(window.location.search).referrer;
+  let referrer = queryString.parse(window.location.search).ref;
 
   if (Array.isArray(referrer) || !referrer) {
     referrer = '';


### PR DESCRIPTION
Close #668 

サインアップのクエリ文字列が `&referrer=geolonia.com` だと入力する時にタイポしやすいというフィードバックが合ったので、`&ref=geolonia.com` に変更しました。