### PR TITLE
Ignore dependabot in steps which requires authority

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -66,7 +66,9 @@ jobs:
 
       - name: Post comment
         uses: actions/github-script@v4
-        if: github.event_name == 'pull_request'
+        if: |
+          github.event_name == 'pull_request' &&
+          contain(github.actor, 'dependabot')
         env:
           POSTING_COMMENT_BODY: ${{ steps.compare_bundle_size.outputs.report }}
         with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/github-script@v4
         if: |
           github.event_name == 'pull_request' &&
-          contain(github.actor, 'dependabot')
+          contains(github.actor, 'dependabot')
         env:
           POSTING_COMMENT_BODY: ${{ steps.compare_bundle_size.outputs.report }}
         with:


### PR DESCRIPTION
Dependabot のプルリクエストではコメントをポストする step が失敗するため