### PR TITLE
Fix chart billing period

### DIFF
--- a/src/components/Team/Billing/usage-chart.tsx
+++ b/src/components/Team/Billing/usage-chart.tsx
@@ -37,7 +37,7 @@ const CHARTJS_OPTIONS: ChartOptions<'bar'> = {
 const getRangeDate = (startDate: moment.Moment, endDate: moment.Moment) => {
   const dates: moment.Moment[] = [];
   let currentDate: moment.Moment = startDate;
-  while (currentDate < endDate) {
+  while (currentDate <= endDate) {
     dates.push(currentDate);
     currentDate = currentDate.clone().add(1, 'days');
   }


### PR DESCRIPTION
バーチャートの最後の1日が欠けているので、漏れないように変更。
なお、1ヶ月間として 10/5 - 11/4 の期間を表示したいので、サーバー側で 1日減らす処理をこちらで追加してます。
https://github.com/geolonia/api.app.geolonia.com/pull/242