### PR TITLE
支払いページ改修

### DIFF
--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -156,7 +156,8 @@ const BillingInner: React.FC<BillingInnerProps> = (props) => {
             </Typography>
             <div className={classNames('usage-card-content', isRestricted ? ' is-restricted' : '')}>
               {!usage || typeof usage.count !== 'number' ? '-' : usage.count.toLocaleString()}
-              <small>{sprintf(__(' / %s loads'), maxLoadCount.toLocaleString())}</small>
+              {/* NOTE: 青天井の地図ロードは、現在十分に大きい maxLoadCount を指定することで実装している。 */}
+              <small>{sprintf(__(' / %s loads'), maxLoadCount >= 999_999_999 ? '∞' : maxLoadCount.toLocaleString())}</small>
             </div>
             {/* NOTE: 未更新時（usage.updated = 1970-01-01T00:00:00Z が API から返ってくる） は、非表示にする */ }
             {(usage?.updated && usage.updated >= '2000-01-01T00:00:00Z') && <>

--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -89,7 +89,7 @@ const BillingInner: React.FC<BillingInnerProps> = (props) => {
     await updateTeam({ teamId, planId });
   }, [planId, teamId, updateTeam]);
 
-  const isOwner = team.role === Roles.Owner;
+  const isOwner = team.role === Roles.Owner || team.role ===  Roles.Operator;
   const currentPlan = plans.find((p) => p.planId === planId);
   const { selectedTeam } = useSelectedTeam();
 

--- a/src/components/Team/Billing.tsx
+++ b/src/components/Team/Billing.tsx
@@ -156,7 +156,7 @@ const BillingInner: React.FC<BillingInnerProps> = (props) => {
             </Typography>
             <div className={classNames('usage-card-content', isRestricted ? ' is-restricted' : '')}>
               {!usage || typeof usage.count !== 'number' ? '-' : usage.count.toLocaleString()}
-              {/* NOTE: 青天井の地図ロードは、現在十分に大きい maxLoadCount を指定することで実装している。 */}
+              {/* NOTE: 無制限の地図ロードは、十分に大きい maxLoadCount を指定することで現在実装している。 */}
               <small>{sprintf(__(' / %s loads'), maxLoadCount >= 999_999_999 ? '∞' : maxLoadCount.toLocaleString())}</small>
             </div>
             {/* NOTE: 未更新時（usage.updated = 1970-01-01T00:00:00Z が API から返ってくる） は、非表示にする */ }

--- a/src/components/Team/Billing/usage-chart.tsx
+++ b/src/components/Team/Billing/usage-chart.tsx
@@ -18,7 +18,6 @@ import { DatePicker } from '../../custom/date-picker';
 import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import Grid from '@material-ui/core/Grid';
 
 const CHARTJS_OPTIONS: ChartOptions<'bar'> = {
   responsive: true,

--- a/src/components/Team/Billing/usage-chart.tsx
+++ b/src/components/Team/Billing/usage-chart.tsx
@@ -13,6 +13,11 @@ import IconButton from '@material-ui/core/IconButton';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import Box from '@material-ui/core/Box';
+import { DatePicker } from '../../custom/date-picker';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Grid from '@material-ui/core/Grid';
 
 
 const CHARTJS_OPTIONS: ChartOptions<'bar'> = {
@@ -167,12 +172,12 @@ const UsageChart: React.FC<UsageChartProps> = (props) => {
         <Bar data={chartData} options={CHARTJS_OPTIONS} id={'chart-usage-api-key'} height={100} />
         <p className="chart-helper-text">{__('API keys with no map loads will not be shown in the graph.')}</p>
       </Box>
-      <Box position={'absolute'} left={0} bottom={'50%'}>
+      <Box position={'absolute'} left={-10} bottom={'50%'}>
         <IconButton onClick={onPrevClick} disabled={!subOrFreePlan || isFetching}>
           <ChevronLeft fontSize={'large'} />
         </IconButton>
       </Box>
-      <Box position={'absolute'} right={0} bottom={'50%'}>
+      <Box position={'absolute'} right={-10} bottom={'50%'}>
         <IconButton onClick={onNextClick} disabled={!subOrFreePlan || isFetching}>
           <ChevronRight fontSize={'large'} />
         </IconButton>

--- a/src/components/Team/Billing/usage-chart.tsx
+++ b/src/components/Team/Billing/usage-chart.tsx
@@ -37,7 +37,7 @@ const CHARTJS_OPTIONS: ChartOptions<'bar'> = {
 const getRangeDate = (startDate: moment.Moment, endDate: moment.Moment) => {
   const dates: moment.Moment[] = [];
   let currentDate: moment.Moment = startDate;
-  while (currentDate < endDate) {
+  while (currentDate <= endDate) {
     dates.push(currentDate);
     currentDate = currentDate.clone().add(1, 'days');
   }

--- a/src/components/Team/Billing/usage-chart.tsx
+++ b/src/components/Team/Billing/usage-chart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback, useEffect } from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import { Bar } from 'react-chartjs-2';
@@ -31,7 +31,7 @@ const CHARTJS_OPTIONS: ChartOptions<'bar'> = {
   },
   plugins: {
     legend: {
-      position: 'bottom',
+      display: false,
     },
     tooltip: {
       enabled: false,
@@ -181,10 +181,8 @@ const UsageChart: React.FC<UsageChartProps> = (props) => {
     setSubQueryDateRange({ usageStart: start, usageEnd: end });
   }, [end, start]);
 
-  const onDownloadClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+  const statisticsData = useMemo(() => {
     if (subOrFreePlan && chartData) {
-      const usageStart = moment(subOrFreePlan.current_period_start).format('YYYY-MM-DD');
-      const usageEnd = moment(subOrFreePlan.current_period_end).format('YYYY-MM-DD');
       const headerItems = [__('date'), ...chartData.datasets.map((dataset) => dataset.keyName)];
       const rows = getRangeDate(
         moment(subOrFreePlan.current_period_start),
@@ -192,17 +190,14 @@ const UsageChart: React.FC<UsageChartProps> = (props) => {
       )
         .map((date, index) => [date.format('YYYY-MM-DD'), ...chartData.datasets.map((dataset) => dataset.data[index])]);
 
-      let data: string;
-      const anchor = document.createElement('a');
-      const { format } = e.currentTarget.dataset;
-      if (format === 'csv') {
-        const header = headerItems.map((val) => `"${val}"`).join(',');
-        data = [header, ...rows.map((row) => row.join(','))].join('\n');
-        anchor.download = `${usageStart}_${usageEnd}.${format}`;
-      } else if (format === 'html') {
-        const summary = [];
 
-        data = `<html>
+      const csvHeader = headerItems.map((val) => `"${val}"`).join(',');
+      const csv: string = [csvHeader, ...rows.map((row) => row.join(','))].join('\n');
+
+      let html: string;
+      const summary: (string | number)[] = [];
+
+      html = `<html>
           <head>
             <meta charset="utf-8">
             <style>
@@ -213,47 +208,77 @@ const UsageChart: React.FC<UsageChartProps> = (props) => {
           </head>
           <body>
             <table>`;
-        data += `<thead><tr>${headerItems.map((item) => `<th>${item}</th>`).join('')}</tr></thead>`;
-        data += '<tbody>';
-        for (let index1 = 0; index1 < rows.length; index1++) {
-          data += '<tr>';
-          for (let index2 = 0; index2 < rows[index1].length; index2++) {
-            const value = rows[index1][index2];
-            if (index2 === 0) {
-              summary[index2] = __('sub total');
-              data += `<th>${value}</th>`;
-            } else {
-              if (summary[index2] === undefined) {
-                summary[index2] = 0;
-              }
-              (summary[index2] as number) += (value as number);
-              data += `<td>${value}</td>`;
-            }
-          }
-          data += '</tr>';
-        }
-        data += '</tbody>';
-        data += '<tfoot>';
-        data += '<tr>';
-        for (let index = 0; index < summary.length; index++) {
-          const value = summary[index];
-          if (index === 0) {
-            data += `<th>${value}</th>`;
+      html += `<thead><tr>${headerItems.map((item) => `<th>${item}</th>`).join('')}</tr></thead>`;
+      html += '<tbody>';
+      for (let index1 = 0; index1 < rows.length; index1++) {
+        html += '<tr>';
+        for (let index2 = 0; index2 < rows[index1].length; index2++) {
+          const value = rows[index1][index2];
+          if (index2 === 0) {
+            summary[index2] = __('sub total');
+            html += `<th>${value}</th>`;
           } else {
-            data += `<td>${value}</td>`;
+            if (summary[index2] === undefined) {
+              summary[index2] = 0;
+            }
+            (summary[index2] as number) += (value as number);
+            html += `<td>${value}</td>`;
           }
         }
-        data += '</tr>';
-        if (summary.length > 1) {
-          const total = summary.reduce<number>((prev, value) => prev + (typeof value === 'number' ? value : 0), 0);
-          data += `<tr><th>${__('total')}</th>`;
-          for (let index = 0; index < summary.length - 2; index++) {
-            data += '<td></td>';
-          }
-          data += `<td>${total}</td></tr>`;
+        html += '</tr>';
+      }
+      html += '</tbody>';
+      html += '<tfoot>';
+      html += '<tr>';
+      for (let index = 0; index < summary.length; index++) {
+        const value = summary[index];
+        if (index === 0) {
+          html += `<th>${value}</th>`;
+        } else {
+          html += `<td>${value}</td>`;
         }
-        data += '</tfoot>';
-        data += '</table></body></html>';
+      }
+      html += '</tr>';
+
+      const total = summary.reduce<number>((prev, value) => prev + (typeof value === 'number' ? value : 0), 0);
+      if (summary.length > 1) {
+        html += `<tr><th>${__('total')}</th>`;
+        for (let index = 0; index < summary.length - 2; index++) {
+          html += '<td></td>';
+        }
+        html += `<td>${total}</td></tr>`;
+      }
+      html += '</tfoot>';
+      html += '</table></body></html>';
+
+      const legendItems = headerItems.reduce<{ [keyName: string]: { value: number, color: string } }>((prev, keyName, index) => {
+        if (index > 0) {
+          prev[keyName] = {
+            value: summary[index] as number,
+            color: chartData.datasets[index - 1].backgroundColor,
+          };
+        }
+        return prev;
+      }, {});
+
+      return { csv, html, total, legendItems };
+    }
+    return null;
+  }, [chartData, subOrFreePlan]);
+
+
+  const onDownloadClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    if (subOrFreePlan && statisticsData) {
+      let data: string;
+      const anchor = document.createElement('a');
+      const { format } = e.currentTarget.dataset;
+      if (format === 'csv') {
+        data = statisticsData.csv!;
+        const usageStart = moment(subOrFreePlan.current_period_start).format('YYYY-MM-DD');
+        const usageEnd = moment(subOrFreePlan.current_period_end).format('YYYY-MM-DD');
+        anchor.download = `${usageStart}_${usageEnd}.${format}`;
+      } else if (format === 'html') {
+        data = statisticsData.html!;
         anchor.target = '_blank';
       } else {
         throw new Error(`Invalid format ${format}.`);
@@ -267,7 +292,7 @@ const UsageChart: React.FC<UsageChartProps> = (props) => {
       document.body.removeChild(anchor);
       URL.revokeObjectURL(blobUrl);
     }
-  }, [chartData, subOrFreePlan]);
+  }, [statisticsData, subOrFreePlan]);
 
   if (typeof chartData === 'undefined') {
     return null;
@@ -324,10 +349,33 @@ const UsageChart: React.FC<UsageChartProps> = (props) => {
         </Box>
         <div>
           <Bar data={chartData} options={CHARTJS_OPTIONS} id={'chart-usage-api-key'} height={100} />
-          <p className="chart-helper-text">
-            {__('API keys with no map loads will not be shown in the graph.')}
-          </p>
         </div>
+        { statisticsData && <>
+          <p style={{display: 'flex', justifyContent: 'center' }}>
+            {
+              Object.keys(statisticsData.legendItems).map((keyName) => {
+                const { value, color } = statisticsData.legendItems[keyName];
+                return <div style={ { display: 'inline', margin: '0 10px' } } key={keyName}>
+                  <i style={{
+                    display: 'inline-block',
+                    width: 40,
+                    height: 12,
+                    background: color,
+                    marginRight: 10,
+                  }} />
+                  {`${keyName}: ${value}`}
+                </div>;
+              })
+            }
+          </p>
+          <p style={{display: 'flex', justifyContent: 'center' }}>
+            <em style={ { fontWeight: 'bold', fontStyle: 'normal', textTransform: 'uppercase' } }>{sprintf(__('total: %s'), statisticsData.total)}</em>
+          </p>
+        </>
+        }
+        <p className="chart-helper-text">
+          {__('API keys with no map loads will not be shown in the graph.')}
+        </p>
       </Box>
       <Box position={'absolute'} left={-10} bottom={'50%'}>
         <IconButton onClick={onPrevClick} disabled={!subOrFreePlan || isFetching}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const Roles = {
   Owner: 'Owner' as const,
   Member: 'Member' as const,
   Suspended: 'Suspended' as const,
+  Operator: 'Operator' as const,
 };
 
 export const errorCodes = {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -180,7 +180,7 @@ declare namespace Geolonia {
       current_period_end: string
     };
   };
-  type Role = 'Owner' | 'Member' | 'Suspended';
+  type Role = 'Owner' | 'Member' | 'Suspended' | 'Operator';
   type Member = Omit<Geolonia.User, 'links'> & {
     userSub: string;
     role: Role;

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -339,6 +339,7 @@
       "Download": ["ダウンロード"],
       "HTML format": ["HTML フォーマット"],
       "CSV format": ["CSV フォーマット"],
+      "total: %s": ["合計: %s"],
       "API keys with no map loads will not be shown in the graph.": [
         "表示回数の無いAPIキーはグラフに表示されません。"
       ],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -64,7 +64,7 @@ msgstr "確認のために delete と入力してください。"
 
 #: src/components/Data/GeoJson.tsx:53 src/components/Data/GeoJsons.tsx:80
 #: src/components/Maps/APIKey.tsx:92 src/components/Maps/APIKeys.tsx:37
-#: src/components/Navigator.tsx:265 src/components/Team/Billing.tsx:316
+#: src/components/Navigator.tsx:265 src/components/Team/Billing.tsx:317
 #: src/components/Team/general/index.tsx:26
 #: src/components/Team/members/index.tsx:149 src/components/User/User.tsx:15
 msgid "Home"
@@ -767,35 +767,35 @@ msgstr "次回のお支払日"
 msgid "Map loads"
 msgstr "地図の表示回数"
 
-#: src/components/Team/Billing.tsx:159
+#: src/components/Team/Billing.tsx:160
 msgid " / %s loads"
 msgstr " / %s 回"
 
-#: src/components/Team/Billing.tsx:163
+#: src/components/Team/Billing.tsx:164
 msgid "Last updated %s"
 msgstr "最終更新: %s"
 
-#: src/components/Team/Billing.tsx:166
+#: src/components/Team/Billing.tsx:167
 msgid "Map loads have reached the limit."
 msgstr "地図表示回数が上限に達したため表示が制限されています。"
 
-#: src/components/Team/Billing.tsx:167
+#: src/components/Team/Billing.tsx:168
 msgid " Please upgrade your plan to unlock it."
 msgstr "制限を解除するにはプランをアップグレードしてください。"
 
-#: src/components/Team/Billing.tsx:174
+#: src/components/Team/Billing.tsx:175
 msgid "Charges"
 msgstr "料金"
 
-#: src/components/Team/Billing.tsx:196
+#: src/components/Team/Billing.tsx:197
 msgid "Payment information"
 msgstr "支払い情報"
 
-#: src/components/Team/Billing.tsx:206
+#: src/components/Team/Billing.tsx:207
 msgid "Current account credit:"
 msgstr "クレジット残高"
 
-#: src/components/Team/Billing.tsx:210
+#: src/components/Team/Billing.tsx:211
 msgid ""
 " : While this account has credits available, payments will deduct from "
 "account credit instead of the registered credit card."
@@ -803,54 +803,54 @@ msgstr ""
 "　(現在、クレジットが適用されています。クレジット残高が残っている場合、請求は"
 "クレジット残高から支払われます。)"
 
-#: src/components/Team/Billing.tsx:215
+#: src/components/Team/Billing.tsx:216
 msgid "Payment method:"
 msgstr "支払い方法"
 
-#: src/components/Team/Billing.tsx:219
+#: src/components/Team/Billing.tsx:220
 msgid "ending in **%1$s"
 msgstr "クレジットカード（末尾の番号 **%1$s）"
 
-#: src/components/Team/Billing.tsx:229
+#: src/components/Team/Billing.tsx:230
 msgid "Change payment method"
 msgstr "支払い方法を変更"
 
-#: src/components/Team/Billing.tsx:242
+#: src/components/Team/Billing.tsx:243
 msgid "Current Plan"
 msgstr "現在のプラン"
 
-#: src/components/Team/Billing.tsx:248
+#: src/components/Team/Billing.tsx:249
 msgid "Scheduled to expire on %1$s"
 msgstr "%1$s にキャンセルされます"
 
-#: src/components/Team/Billing.tsx:267
+#: src/components/Team/Billing.tsx:268
 msgid "Resume subscription"
 msgstr "自動更新を再開"
 
-#: src/components/Team/Billing.tsx:279
+#: src/components/Team/Billing.tsx:280
 msgid "Change Plan"
 msgstr "プランを変更"
 
-#: src/components/Team/Billing.tsx:295
+#: src/components/Team/Billing.tsx:296
 msgid "Learn more about plans on the pricing page."
 msgstr "プラン詳細については、料金ページをご覧ください。"
 
-#: src/components/Team/Billing.tsx:320 src/components/Team/general/index.tsx:30
+#: src/components/Team/Billing.tsx:321 src/components/Team/general/index.tsx:30
 #: src/components/Team/members/index.tsx:153
 msgid "Team settings"
 msgstr "チーム設定"
 
-#: src/components/Team/Billing.tsx:334
+#: src/components/Team/Billing.tsx:335
 msgid "Billing and Plans"
 msgstr "料金プランとお支払い"
 
-#: src/components/Team/Billing.tsx:335
+#: src/components/Team/Billing.tsx:336
 msgid ""
 "You can check and change your current pricing plan and usage status of Team "
 "%s."
 msgstr "チーム「%s」の現在の料金プラン・利用状況の確認、変更ができます。"
 
-#: src/components/Team/Billing.tsx:361
+#: src/components/Team/Billing.tsx:362
 msgid "Payment history"
 msgstr "支払い履歴"
 
@@ -860,7 +860,7 @@ msgstr "支払い履歴はありません。"
 
 #: src/components/Team/Billing/payment-method-modal.tsx:107
 #: src/components/Team/Billing/plan-modal.tsx:131
-#: src/components/Team/Billing/usage-chart.tsx:302
+#: src/components/Team/Billing/usage-chart.tsx:328
 msgid "Update"
 msgstr "更新"
 
@@ -902,43 +902,47 @@ msgstr ""
 msgid "Your plan"
 msgstr "あなたのプラン"
 
-#: src/components/Team/Billing/usage-chart.tsx:189
+#: src/components/Team/Billing/usage-chart.tsx:186
 msgid "date"
 msgstr "日付"
 
-#: src/components/Team/Billing/usage-chart.tsx:224
+#: src/components/Team/Billing/usage-chart.tsx:218
 msgid "sub total"
 msgstr "小計"
 
-#: src/components/Team/Billing/usage-chart.tsx:250
+#: src/components/Team/Billing/usage-chart.tsx:245
 msgid "total"
 msgstr "合計"
 
-#: src/components/Team/Billing/usage-chart.tsx:284
+#: src/components/Team/Billing/usage-chart.tsx:310
 msgid "Map loads details by API key"
 msgstr "API キー別の地図の表示回数の詳細"
 
-#: src/components/Team/Billing/usage-chart.tsx:293
+#: src/components/Team/Billing/usage-chart.tsx:319
 msgid "Start date"
 msgstr "開始日"
 
-#: src/components/Team/Billing/usage-chart.tsx:294
+#: src/components/Team/Billing/usage-chart.tsx:320
 msgid "End date"
 msgstr "終了日"
 
-#: src/components/Team/Billing/usage-chart.tsx:311
+#: src/components/Team/Billing/usage-chart.tsx:337
 msgid "Download"
 msgstr "ダウンロード"
 
-#: src/components/Team/Billing/usage-chart.tsx:320
+#: src/components/Team/Billing/usage-chart.tsx:346
 msgid "HTML format"
 msgstr "HTML フォーマット"
 
-#: src/components/Team/Billing/usage-chart.tsx:321
+#: src/components/Team/Billing/usage-chart.tsx:347
 msgid "CSV format"
 msgstr "CSV フォーマット"
 
-#: src/components/Team/Billing/usage-chart.tsx:327
+#: src/components/Team/Billing/usage-chart.tsx:372
+msgid "total: %s"
+msgstr "合計: %s"
+
+#: src/components/Team/Billing/usage-chart.tsx:377
 msgid "API keys with no map loads will not be shown in the graph."
 msgstr "表示回数の無いAPIキーはグラフに表示されません。"
 
@@ -1006,7 +1010,7 @@ msgid "Delete"
 msgstr "削除"
 
 #: src/components/Team/general/delete.tsx:57
-#: src/components/custom/get-geolonia.tsx:129 src/constants.ts:35
+#: src/components/custom/get-geolonia.tsx:129 src/constants.ts:36
 #: src/lib/cognito/parse-error.ts:51
 msgid "Unknown error."
 msgstr "不明なエラー。"
@@ -1458,11 +1462,11 @@ msgid ""
 msgstr ""
 "Eメールを確認して <code>123456</code> のような検証コードを入力してください。"
 
-#: src/constants.ts:29
+#: src/constants.ts:30
 msgid "You are not authorized to do this operation."
 msgstr "この操作を行う権限がありません。"
 
-#: src/constants.ts:31
+#: src/constants.ts:32
 msgid "Network error."
 msgstr "通信エラー。"
 

--- a/src/lang/lang.pot
+++ b/src/lang/lang.pot
@@ -54,7 +54,7 @@ msgstr ""
 #: src/components/Maps/APIKey.tsx:92
 #: src/components/Maps/APIKeys.tsx:37
 #: src/components/Navigator.tsx:265
-#: src/components/Team/Billing.tsx:316
+#: src/components/Team/Billing.tsx:317
 #: src/components/Team/general/index.tsx:26
 #: src/components/Team/members/index.tsx:149
 #: src/components/User/User.tsx:15
@@ -712,89 +712,89 @@ msgstr ""
 msgid "Map loads"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:159
+#: src/components/Team/Billing.tsx:160
 msgid " / %s loads"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:163
+#: src/components/Team/Billing.tsx:164
 msgid "Last updated %s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:166
+#: src/components/Team/Billing.tsx:167
 msgid "Map loads have reached the limit."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:167
+#: src/components/Team/Billing.tsx:168
 msgid " Please upgrade your plan to unlock it."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:174
+#: src/components/Team/Billing.tsx:175
 msgid "Charges"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:196
+#: src/components/Team/Billing.tsx:197
 msgid "Payment information"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:206
+#: src/components/Team/Billing.tsx:207
 msgid "Current account credit:"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:210
+#: src/components/Team/Billing.tsx:211
 msgid ""
 " : While this account has credits available, payments will deduct from "
 "account credit instead of the registered credit card."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:215
+#: src/components/Team/Billing.tsx:216
 msgid "Payment method:"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:219
+#: src/components/Team/Billing.tsx:220
 msgid "ending in **%1$s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:229
+#: src/components/Team/Billing.tsx:230
 msgid "Change payment method"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:242
+#: src/components/Team/Billing.tsx:243
 msgid "Current Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:248
+#: src/components/Team/Billing.tsx:249
 msgid "Scheduled to expire on %1$s"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:267
+#: src/components/Team/Billing.tsx:268
 msgid "Resume subscription"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:279
+#: src/components/Team/Billing.tsx:280
 msgid "Change Plan"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:295
+#: src/components/Team/Billing.tsx:296
 msgid "Learn more about plans on the pricing page."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:320
+#: src/components/Team/Billing.tsx:321
 #: src/components/Team/general/index.tsx:30
 #: src/components/Team/members/index.tsx:153
 msgid "Team settings"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:334
+#: src/components/Team/Billing.tsx:335
 msgid "Billing and Plans"
 msgstr ""
 
-#: src/components/Team/Billing.tsx:335
+#: src/components/Team/Billing.tsx:336
 msgid ""
 "You can check and change your current pricing plan and usage status of Team "
 "%s."
 msgstr ""
 
-#: src/components/Team/Billing.tsx:361
+#: src/components/Team/Billing.tsx:362
 msgid "Payment history"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 
 #: src/components/Team/Billing/payment-method-modal.tsx:107
 #: src/components/Team/Billing/plan-modal.tsx:131
-#: src/components/Team/Billing/usage-chart.tsx:302
+#: src/components/Team/Billing/usage-chart.tsx:328
 msgid "Update"
 msgstr ""
 
@@ -843,43 +843,47 @@ msgstr ""
 msgid "Your plan"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:189
+#: src/components/Team/Billing/usage-chart.tsx:186
 msgid "date"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:224
+#: src/components/Team/Billing/usage-chart.tsx:218
 msgid "sub total"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:250
+#: src/components/Team/Billing/usage-chart.tsx:245
 msgid "total"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:284
+#: src/components/Team/Billing/usage-chart.tsx:310
 msgid "Map loads details by API key"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:293
+#: src/components/Team/Billing/usage-chart.tsx:319
 msgid "Start date"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:294
+#: src/components/Team/Billing/usage-chart.tsx:320
 msgid "End date"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:311
+#: src/components/Team/Billing/usage-chart.tsx:337
 msgid "Download"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:320
+#: src/components/Team/Billing/usage-chart.tsx:346
 msgid "HTML format"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:321
+#: src/components/Team/Billing/usage-chart.tsx:347
 msgid "CSV format"
 msgstr ""
 
-#: src/components/Team/Billing/usage-chart.tsx:327
+#: src/components/Team/Billing/usage-chart.tsx:372
+msgid "total: %s"
+msgstr ""
+
+#: src/components/Team/Billing/usage-chart.tsx:377
 msgid "API keys with no map loads will not be shown in the graph."
 msgstr ""
 
@@ -946,7 +950,7 @@ msgstr ""
 
 #: src/components/Team/general/delete.tsx:57
 #: src/components/custom/get-geolonia.tsx:129
-#: src/constants.ts:35
+#: src/constants.ts:36
 #: src/lib/cognito/parse-error.ts:51
 msgid "Unknown error."
 msgstr ""
@@ -1382,11 +1386,11 @@ msgid ""
 "<code>123456</code>."
 msgstr ""
 
-#: src/constants.ts:29
+#: src/constants.ts:30
 msgid "You are not authorized to do this operation."
 msgstr ""
 
-#: src/constants.ts:31
+#: src/constants.ts:32
 msgid "Network error."
 msgstr ""
 

--- a/src/redux/actions/team-member.ts
+++ b/src/redux/actions/team-member.ts
@@ -9,6 +9,7 @@ export const RoleOrders = {
   Owner: 0,
   Member: 1,
   Suspended: 2,
+  Operator: 1000,
 };
 
 type State = Geolonia.Redux.State.TeamMember;


### PR DESCRIPTION
- 地図ロード数制限なしの場合は ∞ を表示
- ボタンの位置修正(前月・次月ボタンが内側に入り込んでいたので直した)
- Operator ロールでも「今月の利用状況」セクションを表示
- チャートの判例を ChartJS のキャンバスから HTML に作り直して合計を表示し、かつコピペできるようにした
<img width="965" alt="スクリーンショット 2022-10-12 11 31 59" src="https://user-images.githubusercontent.com/6292312/195236157-04dc8be3-5868-46a1-ab53-8b500b397cdf.png">
