### PR TITLE
Billing page fix

### DIFF
--- a/src/components/Team/Billing/payment-history.tsx
+++ b/src/components/Team/Billing/payment-history.tsx
@@ -76,7 +76,13 @@ const PaymentHistoryInvoiceRow: React.FC<PaymentHistoryInvoiceRowProps> = (props
             ))}
         </ul>
       </TableCell>
-      <TableCell>{`${payment}${charge && charge.refunded ? ` ${__('Refunded')}` : ''}`}</TableCell>
+      <TableCell>
+        {
+          charge && charge.refunded ?
+            <><del>{payment}</del>{' '}{__('Refunded')}</> :
+            <span>{payment}</span>
+        }
+      </TableCell>
       <TableCell>
         {receipt_url && (
           <a

--- a/src/components/Team/Billing/payment-history.tsx
+++ b/src/components/Team/Billing/payment-history.tsx
@@ -38,8 +38,7 @@ const PaymentHistoryInvoiceRow: React.FC<PaymentHistoryInvoiceRowProps> = (props
   const {
     total,
     currency,
-    period_start,
-    period_end,
+    paid_at,
     ending_balance,
     starting_balance,
     descriptions,
@@ -56,7 +55,7 @@ const PaymentHistoryInvoiceRow: React.FC<PaymentHistoryInvoiceRowProps> = (props
   //   ((ending_balance || 0) - starting_balance)
   // );
 
-  const duration = `${moment(period_start * 1000).format('YYYY/MM/DD')} - ${moment(period_end * 1000).format('YYYY/MM/DD')}`;
+  const paid_date = paid_at === null ? '-' : `${moment(paid_at * 1000).format('YYYY/MM/DD')}`;
   const payment = formattedActualPayment;
   const receipt_url = charge && charge.receipt_url;
 
@@ -66,7 +65,7 @@ const PaymentHistoryInvoiceRow: React.FC<PaymentHistoryInvoiceRowProps> = (props
 
   return (
     <TableRow>
-      <TableCell>{duration}</TableCell>
+      <TableCell>{paid_date}</TableCell>
       <TableCell>
         <ul>
           {descriptions

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -218,6 +218,7 @@ declare namespace Geolonia {
     id: string;
     total: number;
     currency: string;
+    paid_at: number | null;
     period_start: number;
     period_end: number;
     ending_balance: null | number;

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -315,7 +315,7 @@
       ],
       "Payment history": ["支払い履歴"],
       "No payment history.": ["支払い履歴はありません。"],
-      "Refunded": ["返金"],
+      "Refunded": ["返金済み"],
       "Update": ["更新"],
       "Unknown Error.": ["不明なエラー。"],
       "Card information": ["クレジットカード情報"],

--- a/src/lang/ja.po
+++ b/src/lang/ja.po
@@ -864,7 +864,7 @@ msgstr "支払い履歴はありません。"
 
 #: src/components/Team/Billing/payment-history.tsx:79
 msgid "Refunded"
-msgstr "返金"
+msgstr "返金済み"
 
 #: src/components/Team/Billing/payment-method-modal.tsx:107
 #: src/components/Team/Billing/plan-modal.tsx:131


### PR DESCRIPTION
- API からは支払い日のデータを受け取り (geolonia/api.app.geolonia.com/pull/247)、それを請求書の日付としてリストに表示
- 返金の時は金額に取り消し線


<img width="384" alt="スクリーンショット 2022-11-02 12 04 27" src="https://user-images.githubusercontent.com/6292312/199385735-4a669482-7c49-42cf-a522-effcb7f11120.png">
