### PR TITLE
Fix GetGeolonia onLoad callback behaivor

### DIFF
--- a/src/components/Maps/APIKey.tsx
+++ b/src/components/Maps/APIKey.tsx
@@ -335,9 +335,7 @@ const ApiKey: React.FC = () => {
             </p>
             <p>
               <GetGeolonia
-                lat={35.6762}
-                lng={139.6503}
-                zoom={10}
+                defaultXYZ={[139.6503, 35.6762, 10]}
                 mapStyle={'geolonia/basic'}
               />
             </p>

--- a/src/components/Maps/APIKey.tsx
+++ b/src/components/Maps/APIKey.tsx
@@ -336,7 +336,7 @@ const ApiKey: React.FC = () => {
             <p>
               <GetGeolonia
                 defaultXYZ={[139.6503, 35.6762, 10]}
-                mapStyle={'geolonia/basic'}
+                mapStyle={'geolonia/basic-v1'}
               />
             </p>
             <Typography component="h3" style={styleH3}>

--- a/src/components/custom/get-geolonia.tsx
+++ b/src/components/custom/get-geolonia.tsx
@@ -202,7 +202,7 @@ export const GetGeolonia: React.FC<Props> = (props: Props) => {
         const [lng, lat, zoom] = defaultXYZ;
         map.flyTo({ center: [lng, lat], zoom });
       } else {
-        moveendCallback(map);
+        moveendCallback(map); // force fire and setState
       }
       map.on('moveend', (ev) => moveendCallback(ev.target));
     });

--- a/src/components/custom/get-geolonia.tsx
+++ b/src/components/custom/get-geolonia.tsx
@@ -97,12 +97,18 @@ export const GetGeolonia: React.FC<Props> = (props: Props) => {
   const { geojsonId, defaultXYZ, marker, mapStyle } = props;
   const simpleVector = geojsonId ? `geolonia://tiles/custom/${geojsonId}` : undefined;
 
+  const defaultLng = defaultXYZ ? defaultXYZ[0] : 0;
+  const defaultLat = defaultXYZ ? defaultXYZ[1] : 0;
+  const defaultZoom = defaultXYZ ? defaultXYZ[2] : 0;
+
   const [open, setOpen] = useState(false);
   const [geocodeText, setGeocodeText] = useState('');
   const [messageVisibility, setMessageVisibilty] = useState<string | false>(false);
 
-  const [lngLatZoom, setLngLatZoom] = useState<[lng: number, lat: number, zoom: number] | null>(null);
-  const [styleIdentifier, setStyleIdentifier] = useState(mapStyle || 'geolonia/basic');
+  const [lngLatZoom, setLngLatZoom] = useState<[lng: number, lat: number, zoom: number] | null>(
+    defaultXYZ || null,
+  );
+  const [styleIdentifier, setStyleIdentifier] = useState(mapStyle || 'geolonia/basic-v1');
   const [htmlSnippet, setHtmlSnippet] = useState('');
 
   const handleClickOpen = useCallback(() => setOpen(true), []);
@@ -111,7 +117,6 @@ export const GetGeolonia: React.FC<Props> = (props: Props) => {
   const handleHtmlSnippetChangeByUser = useCallback((event: React.ChangeEvent<HTMLInputElement>) => setHtmlSnippet(event.target.value), []);
 
   const mapRef = useRef<mapboxgl.Map | null>(null);
-
 
   const handleGeocodeSubmit = useCallback(() => {
     if (!geocodeText) return;
@@ -199,15 +204,9 @@ export const GetGeolonia: React.FC<Props> = (props: Props) => {
     };
 
     map.once('load', () => {
-      if (defaultXYZ) {
-        const [lng, lat, zoom] = defaultXYZ;
-        map.flyTo({ center: [lng, lat], zoom });
-      } else {
-        moveendCallback(map); // force fire and setState
-      }
       map.on('moveend', (ev) => moveendCallback(ev.target));
     });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   return <>
     <Button
@@ -223,6 +222,11 @@ export const GetGeolonia: React.FC<Props> = (props: Props) => {
     <Modal open={open} onClose={handleClose} style={{display: 'flex'}}>
       <div className={'get-geolonia-modal-content'}>
         <GeoloniaMap
+          // We only set the lat/lng/zoom once, because if we set them every time the map is panned,
+          // we'll end up with an infinite loop of re-rendering.
+          lat={`${defaultLat}`}
+          lng={`${defaultLng}`}
+          zoom={`${defaultZoom}`}
           marker={'off'}
           mapRef={mapRef}
           style={{width: '100%', height: 'calc(100% - 150px)'}}

--- a/src/components/custom/get-geolonia.tsx
+++ b/src/components/custom/get-geolonia.tsx
@@ -190,13 +190,14 @@ export const GetGeolonia: React.FC<Props> = (props: Props) => {
 
   }, [lngLatZoom, marker, simpleVector, styleIdentifier]);
 
-  const moveendCallback = useCallback((map: mapboxgl.Map) => {
-    const { lng, lat } = map.getCenter();
-    const zoom = map.getZoom();
-    setLngLatZoom([lng, lat, zoom]);
-  }, []);
-
   const handleMapOnLoad = useCallback((map: mapboxgl.Map) => {
+
+    const moveendCallback = (map: mapboxgl.Map) => {
+      const { lng, lat } = map.getCenter();
+      const zoom = map.getZoom();
+      setLngLatZoom([lng, lat, zoom]);
+    };
+
     map.once('load', () => {
       if (defaultXYZ) {
         const [lng, lat, zoom] = defaultXYZ;


### PR DESCRIPTION
GetGeolonia を表示した際に、デフォルトの位置に地図が移動しなくなったことへの対応です。
Embed React の onLoad コールバックの内部で on('load') としたら期待する動きになりましたが、これは Embed React に期待する挙動ではないため、最適な修正になっていないと思われます。

- ~~[ ] Embed React 側で対応できるのか、するべきなのかを調査~~