### PR TITLE
feat: add catalog-info.yaml for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+
+metadata:
+  namespace: geolonia
+  name: app-geolonia-com
+  title: Dashboard
+  description: Geolonia Maps dashboard application for managing map services.
+  annotations:
+    github.com/project-slug: geolonia/app.geolonia.com
+    backstage.io/source-location: url:https://github.com/geolonia/app.geolonia.com/blob/develop/
+  tags:
+    - dashboard
+    - frontend
+
+spec:
+  type: service
+  lifecycle: production
+  owner: group:geolonia/maps-team
+  system: geolonia/geolonia-maps

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,3 +18,7 @@ spec:
   lifecycle: production
   owner: group:geolonia/maps-team
   system: geolonia/geolonia-maps
+  dependsOn:
+    - component:geolonia/api-app-geolonia-com
+  consumesApis:
+    - api:geolonia/maps-app-api


### PR DESCRIPTION
## Summary

- Backstage でのサービスカタログ可視化のために `catalog-info.yaml` を追加します
- Geolonia Maps システムの一部として、maps-team がオーナーとして登録されます

## Changes

- `catalog-info.yaml` を新規作成（Backstage Component 定義）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **その他**
  * Backstageカタログに新しいアプリケーションコンポーネントを追加しました。これにより、本番稼働中のサービスとしての登録、オーナー情報や所属システムの表示、依存関係と利用するAPIの宣言が可能になり、運用管理と可視性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->