### PR TITLE
docs: master への直接変更禁止ルールを明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## ブランチ運用ルール（MUST）
 
-- default branch は `develop`（GitHub organization rule で保護されているのはこのブランチのみ）。
-- `main` が branch protection で保護されていなくても、`develop` を経由せず `main` へ直接変更を加えてはならない。
-- `main` への直接変更は staging 環境での動作確認をスキップして production 環境へ変更を適用することになるため、原則禁止。
-- production 環境が staging 環境よりも進んでいる（内容が乖離した）状態を発生させてはならない。
-- PR は必ず `develop` を経由して `main` に取り込むこと。feature/fix ブランチは `develop` から作成し、`develop` を base に PR を作成すること。
-- PR の base branch を `main` に向けてはならない。
+- default branch は `develop`（GitHub organization rule で保護されているのはこのブランチのみ）。production 環境が参照するのは `master`（このリポジトリに `main` は存在しない）。
+- `master` が branch protection で保護されていなくても、`develop` を経由せず `master` へ直接変更を加えてはならない。
+- `master` への直接変更は staging 環境での動作確認をスキップして production 環境へ変更を適用することになるため、原則禁止。
+- production 環境（`master`）が staging 環境（`develop`）よりも進んでいる（内容が乖離した）状態を発生させてはならない。
+- PR は必ず `develop` を経由して `master` に取り込むこと。feature/fix ブランチは `develop` から作成し、`develop` を base に PR を作成すること。
+- PR の base branch を `master` に向けてはならない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+## ブランチ運用ルール（MUST）
+
+- default branch は `develop`（GitHub organization rule で保護されているのはこのブランチのみ）。
+- `main` が branch protection で保護されていなくても、`develop` を経由せず `main` へ直接変更を加えてはならない。
+- `main` への直接変更は staging 環境での動作確認をスキップして production 環境へ変更を適用することになるため、原則禁止。
+- production 環境が staging 環境よりも進んでいる（内容が乖離した）状態を発生させてはならない。
+- PR は必ず `develop` を経由して `main` に取り込むこと。feature/fix ブランチは `develop` から作成し、`develop` を base に PR を作成すること。
+- PR の base branch を `main` に向けてはならない。

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ## ブランチ運用ルール（重要）
 
-- このリポジトリの default branch は `develop` です。GitHub の organization rule (branch protection) が保護しているのはこの `develop` のみで、`main` は保護対象外です。
-- ただし `main` が組織ルールで保護されていない場合であっても、`develop` を経由せず `main` へ直接変更を加えることは禁止です。
-- `main` への直接変更は、staging 環境での動作確認をスキップして production 環境へ変更を適用することを意味するため、原則として許可されません。
-- production 環境が staging 環境よりも進んでいる（内容が乖離している）状態を発生させてはいけません。
-- PR は必ず `develop` を経由して `main` に取り込んでください。feature/fix ブランチは `develop` から作成し、`develop` を base に PR を作成してください。
-- PR の base branch を `main` に向けてはいけません。
+- このリポジトリの default branch は `develop` です。GitHub の organization rule (branch protection) が保護しているのはこの `develop` のみで、production 環境が参照する `master` は保護対象外です（このリポジトリに `main` ブランチは存在しません）。
+- ただし `master` が組織ルールで保護されていない場合であっても、`develop` を経由せず `master` へ直接変更を加えることは禁止です。
+- `master` への直接変更は、staging 環境での動作確認をスキップして production 環境へ変更を適用することを意味するため、原則として許可されません。
+- production 環境（`master`）が staging 環境（`develop`）よりも進んでいる（内容が乖離している）状態を発生させてはいけません。
+- PR は必ず `develop` を経由して `master` に取り込んでください。feature/fix ブランチは `develop` から作成し、`develop` を base に PR を作成してください。
+- PR の base branch を `master` に向けてはいけません。
 
 ## development
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 ![Netlify Status](https://api.netlify.com/api/v1/badges/82532c8e-8d86-4215-a8f7-9fca30cfb132/deploy-status)
 
+## ブランチ運用ルール（重要）
+
+- このリポジトリの default branch は `develop` です。GitHub の organization rule (branch protection) が保護しているのはこの `develop` のみで、`main` は保護対象外です。
+- ただし `main` が組織ルールで保護されていない場合であっても、`develop` を経由せず `main` へ直接変更を加えることは禁止です。
+- `main` への直接変更は、staging 環境での動作確認をスキップして production 環境へ変更を適用することを意味するため、原則として許可されません。
+- production 環境が staging 環境よりも進んでいる（内容が乖離している）状態を発生させてはいけません。
+- PR は必ず `develop` を経由して `main` に取り込んでください。feature/fix ブランチは `develop` から作成し、`develop` を base に PR を作成してください。
+- PR の base branch を `main` に向けてはいけません。
+
 ## development
 
 ```shell


### PR DESCRIPTION
## Summary
- GitHub organization rule が保護しているのは default branch のみで、production 環境が参照する master は保護対象外であることを明記（このリポジトリに main ブランチは存在しない）
- master への直接変更は staging 環境での動作確認をスキップして production に適用することになるため禁止する旨を README.md / CLAUDE.md に追記
- PR は必ず default branch (develop) を経由して master に取り込むことをルール化

## Test plan
- [x] ドキュメント追加のみ、動作影響なし